### PR TITLE
Install same version libvarnishapi1 as Varnish

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
  adduser,
  gcc,
  libc6-dev | libc6.1-dev | libc-dev,
- libvarnishapi1 (>= ${binary:Version})
+ libvarnishapi1 (= ${binary:Version})
 Suggests: varnish-doc
 Provides: varnish, ${Varnish:ABI}, ${Varnish:strictABI}
 Description: state of the art, high-performance web accelerator


### PR DESCRIPTION
This allow simple downgrade of Varnish package, because Varnish API might
not be forward compatible (new libvarnishapi1 with old Varnish).