### PR TITLE
Send stderr to journal, but supress stdout

### DIFF
--- a/redhat/varnish.service
+++ b/redhat/varnish.service
@@ -23,6 +23,8 @@ LimitCORE=infinity
 EnvironmentFile=/etc/varnish/varnish.params
 
 Type=forking
+StandardOutput=null
+StandardError=journal
 PIDFile=/var/run/varnish.pid
 PrivateTmp=true
 ExecStartPre=/usr/sbin/varnishd -C -f $VARNISH_VCL_CONF $DAEMON_OPTS


### PR DESCRIPTION
This prevents the VCL check (-C) from polluting the journal, while still
dumping any error messages from failed compiles to the journal.

The problem with the currently shipped ``varnish.service`` is that on every restart, the full VCL compile output will be sent to the journal.