### PR TITLE
Remove verbose and superfluous ExecStartPre

### DIFF
--- a/debian/varnish.service
+++ b/debian/varnish.service
@@ -5,7 +5,6 @@ Description=Varnish Cache, a high-performance HTTP accelerator
 Type=forking
 LimitNOFILE=131072
 LimitMEMLOCK=82000
-ExecStartPre=/usr/sbin/varnishd -C -f /etc/varnish/default.vcl
 ExecStart=/usr/sbin/varnishd -a :6081 -T localhost:6082 -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,256m
 ExecReload=/usr/share/varnish/reload-vcl
 

--- a/redhat/varnish.service
+++ b/redhat/varnish.service
@@ -23,8 +23,6 @@ LimitCORE=infinity
 EnvironmentFile=/etc/varnish/varnish.params
 
 Type=forking
-StandardOutput=null
-StandardError=journal
 PIDFile=/var/run/varnish.pid
 PrivateTmp=true
 ExecStartPre=/usr/sbin/varnishd -C -f $VARNISH_VCL_CONF $DAEMON_OPTS

--- a/redhat/varnish.service
+++ b/redhat/varnish.service
@@ -25,7 +25,6 @@ EnvironmentFile=/etc/varnish/varnish.params
 Type=forking
 PIDFile=/var/run/varnish.pid
 PrivateTmp=true
-ExecStartPre=/usr/sbin/varnishd -C -f $VARNISH_VCL_CONF $DAEMON_OPTS
 ExecStart=/usr/sbin/varnishd \
 	-P /var/run/varnish.pid \
 	-f $VARNISH_VCL_CONF \

--- a/redhat/varnish.service
+++ b/redhat/varnish.service
@@ -23,6 +23,8 @@ LimitCORE=infinity
 EnvironmentFile=/etc/varnish/varnish.params
 
 Type=forking
+StandardOutput=null
+StandardError=journal
 PIDFile=/var/run/varnish.pid
 PrivateTmp=true
 ExecStartPre=/usr/sbin/varnishd -C -f $VARNISH_VCL_CONF $DAEMON_OPTS


### PR DESCRIPTION
There is no good reason to do a -C run before the actual daemon execution. 
Including this will not prevent systemd from stopping varnishd on errors in the VCL, and it will pollute the journal with the VCL compilation result.