### PR TITLE
Set value of PIDFILE by $SERVICE

### DIFF
--- a/debian/varnish.init
+++ b/debian/varnish.init
@@ -16,11 +16,11 @@
 # Source function library
 . /lib/lsb/init-functions
 
-SERVICE="$(basename ${0})"
+SERVICE="$(readlink -e ${0} | xargs basename)"
 DESC="HTTP accelerator"
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/sbin/varnishd
-PIDFILE=/run/$NAME.pid
+PIDFILE="/run/${SERVICE}.pid"
 
 test -x $DAEMON || { echo "${DAEMON} has no execute bit"; exit 0; }
 


### PR DESCRIPTION
As mentioned in #15 $NAME has been re-factored to $SERVICE on almost all occurences. For $PIDFILE this wasn't done which is fixed by this PR.