### PR TITLE
Move PID argument to the back in init file

### DIFF
--- a/debian/varnish.init
+++ b/debian/varnish.init
@@ -48,7 +48,7 @@ start_varnishd() {
     output=$(/bin/tempfile -s.varnish)
     if start-stop-daemon \
         --start --pidfile ${PIDFILE} --exec ${DAEMON} -- \
-        -P ${PIDFILE} ${DAEMON_OPTS} > ${output} 2>&1; then
+        ${DAEMON_OPTS} -P ${PIDFILE} > ${output} 2>&1; then
         log_end_msg 0
     else
         log_end_msg 1


### PR DESCRIPTION
Move PID argument to the back in init file to allow jail argument to be specified as first argument in `DAEMON_OPTS` in `/etc/default/varnish`.

This fixes issue #18