### PR TITLE
Fix varnishncsa postrotate logrotate script typo

### DIFF
--- a/debian/varnish.logrotate
+++ b/debian/varnish.logrotate
@@ -20,7 +20,7 @@
   missingok
   postrotate
     if [ -d /run/systemd/system ]; then
-       systemctl -q is-active varnishlog.service || exit 0
+       systemctl -q is-active varnishncsa.service || exit 0
     fi
     /usr/sbin/invoke-rc.d varnishncsa reload > /dev/null
   endscript


### PR DESCRIPTION
When varnishlog is not running but varnishncsa is, logrotate script does not reload varnishcsa because of a copy-paste typo.

The [line here](https://github.com/varnishcache/pkg-varnish-cache/blob/master/debian/varnish.logrotate#L23) should be `varnishncsa.service` instead of `varnishlog.service`.