### PR TITLE
systemd service uses /etc/default/varnish

### DIFF
--- a/debian/varnish.default
+++ b/debian/varnish.default
@@ -1,13 +1,11 @@
 # Configuration file for Varnish Cache.
 #
-# /etc/init.d/varnish expects the variables $DAEMON_OPTS, $NFILES and $MEMLOCK
-# to be set from this shell script fragment.
+# /etc/init.d/varnish and systemd service expect the variables $DAEMON_OPTS,
+# $NFILES and $MEMLOCK to be set from this shell script fragment.
 #
-# Note: If systemd is installed, this file is obsolete and ignored.  You will
-# need to copy /lib/systemd/system/varnish.service to /etc/systemd/system/ and
-# edit that file.
 
 # Should we start varnishd at boot?  Set to "no" to disable.
+# Note: If systemd is installed, this variable is obsolete and ignored.
 START=yes
 
 # Maximum number of open files (for ulimit -n)

--- a/debian/varnish.service
+++ b/debian/varnish.service
@@ -3,9 +3,10 @@ Description=Varnish Cache, a high-performance HTTP accelerator
 
 [Service]
 Type=forking
-LimitNOFILE=131072
-LimitMEMLOCK=82000
-ExecStart=/usr/sbin/varnishd -a :6081 -T localhost:6082 -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,256m
+EnvironmentFile=-/etc/default/varnish
+LimitNOFILE=${NFILES:-131072}
+LimitMEMLOCK=${MEMLOCK:-82000}
+ExecStart=/usr/sbin/varnishd $DAEMON_OPTS
 ExecReload=/usr/share/varnish/reload-vcl
 
 [Install]


### PR DESCRIPTION
Service sets /etc/default/varnish as environment file and uses NFILES, MEMLOCK and DAEMON_OPTS variables (but START).