### PR TITLE
Update start_varnishncsa to allow a log format containing spaces

### DIFF
--- a/debian/varnish.varnishncsa.default
+++ b/debian/varnish.varnishncsa.default
@@ -17,3 +17,7 @@
 # a different log format, you can override the DAEMON_OPTS variable
 # from /etc/init.d/varnishncsa here.
 # DAEMON_OPTS="-a -w ${LOGFILE} -D -P ${PIDFILE}"
+#
+# If you want to set a custom log format, you can set the LOG_FORMAT
+# # variable here.
+# LOG_FORMAT=""

--- a/debian/varnish.varnishncsa.init
+++ b/debian/varnish.varnishncsa.init
@@ -40,8 +40,10 @@ start_varnishncsa() {
     output=$(/bin/tempfile -s.varnish)
     log_daemon_msg "Starting $DESC" "$SERVICE"
     create_pid_directory
+    test -n "${LOG_FORMAT}" && LOG_FORMAT="-F${LOG_FORMAT}"
     if start-stop-daemon --start --pidfile ${PIDFILE} \
-        --chuid $USER --exec ${DAEMON} -- ${DAEMON_OPTS} \
+        --chuid $USER --exec ${DAEMON} -- \
+        ${DAEMON_OPTS} "${LOG_FORMAT}" \
         > ${output} 2>&1; then
 	log_end_msg 0
     else


### PR DESCRIPTION
Update the `start_varnishncsa` function to workaround issues with `start-stop-daemon` misinterpretting quoted arguments (see http://stackoverflow.com/q/1661193).