### PR TITLE
Update reload-vcl to not use : as separator for vcl-labels

### DIFF
--- a/debian/reload-vcl
+++ b/debian/reload-vcl
@@ -42,9 +42,9 @@ msg_secret_not_there="Error: Secret file %s does not exist\n"
 if [ -f /proc/sys/kernel/random/uuid ]
 then
     uuid=$(cat /proc/sys/kernel/random/uuid)
-    vcl_label="${LOGNAME}${LOGNAME:+:}${uuid}"
+    vcl_label="${LOGNAME}${LOGNAME:+_}${uuid}"
 else
-    vcl_label="$($date +${LOGNAME}${LOGNAME:+:}%s.%N)"
+    vcl_label="$($date +${LOGNAME}${LOGNAME:+_}%s-%N)"
 fi
 
 # Load defaults file


### PR DESCRIPTION
Change the user -> uuid delimiter to be "_" as UUID contains "-"
Change %s.%N  to %s-%N so that we can differ user from the rest.

This fixes the new rules introduced in https://github.com/varnishcache/varnish-cache/blob/master/bin/varnishd/mgt/mgt_vcl.c

And solves https://github.com/varnishcache/pkg-varnish-cache/issues/42