### PR TITLE
Fix can't reload, if LOGNAME is empty.

### DIFF
--- a/debian/reload-vcl
+++ b/debian/reload-vcl
@@ -42,9 +42,9 @@ msg_secret_not_there="Error: Secret file %s does not exist\n"
 if [ -f /proc/sys/kernel/random/uuid ]
 then
     uuid=$(cat /proc/sys/kernel/random/uuid)
-    vcl_label="${LOGNAME}${LOGNAME:+_}${uuid}"
+    vcl_label="reload_${LOGNAME}${LOGNAME:+_}${uuid}"
 else
-    vcl_label="$($date +${LOGNAME}${LOGNAME:+_}%s-%N)"
+    vcl_label="reload_$($date +${LOGNAME}${LOGNAME:+_}%s-%N)"
 fi
 
 # Load defaults file


### PR DESCRIPTION
If LOGNAME is empty, the first character is UUID or date.
These contains a digit.
But, the first character should be alphabet of the VCL name.

**Errorlog**

```
Sep 16 00:40:02 proxy01 systemd[1]: Reloading Varnish Cache, a high-performance HTTP accelerator.
-- Subject: Unit varnish.service has begun reloading its configuration
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
--
-- Unit varnish.service has begun reloading its configuration
Sep 16 00:40:02 proxy01 varnishd[23955]: CLI telnet 127.0.0.1 48006 127.0.0.1 6082 Rd auth bbbcc18c4ad830f64fd5ea04dd94d63ed5c07139e74b7262d6a1729db50da559
Sep 16 00:40:02 proxy01 varnishd[23955]: CLI telnet 127.0.0.1 48006 127.0.0.1 6082 Wr 200 -----------------------------
                                         Varnish Cache CLI 1.0
                                         -----------------------------
                                         Linux,4.4.0-28-generic,x86_64,-junix,-smalloc,-smalloc,-hcritbit
                                         varnish-5.0.0 revision 99d036f

                                         Type 'help' for command list.
                                         Type 'quit' to close CLI session.
Sep 16 00:40:02 proxy01 varnishd[23955]: CLI telnet 127.0.0.1 48006 127.0.0.1 6082 Rd ping
Sep 16 00:40:02 proxy01 varnishd[23955]: CLI telnet 127.0.0.1 48006 127.0.0.1 6082 Wr 200 PONG 1473954002 1.0
Sep 16 00:40:02 proxy01 varnishd[23955]: CLI telnet 127.0.0.1 48006 127.0.0.1 6082 Rd vcl.load 1d01baa5-df28-429f-aab0-dce24f4a6bd8 /etc/varnish/default.vcl
Sep 16 00:40:02 proxy01 varnishd[23955]: CLI telnet 127.0.0.1 48006 127.0.0.1 6082 Wr 106 Illegal character in VCL name ('1')
Sep 16 00:40:02 proxy01 reload-vcl[24178]: Command failed with error code 106
Sep 16 00:40:02 proxy01 reload-vcl[24178]: Illegal character in VCL name ('1')
Sep 16 00:40:02 proxy01 reload-vcl[24178]: Error: vcl.load 1d01baa5-df28-429f-aab0-dce24f4a6bd8 /etc/varnish/default.vcl failed
Sep 16 00:40:02 proxy01 systemd[1]: varnish.service: Control process exited, code=exited status=1
Sep 16 00:40:02 proxy01 systemd[1]: Reload failed for Varnish Cache, a high-performance HTTP accelerator.
-- Subject: Unit varnish.service has finished reloading its configuration
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
--
-- Unit varnish.service has finished reloading its configuration
--
-- The result is failed.
```

**Environment**

```
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=16.04
DISTRIB_CODENAME=xenial
DISTRIB_DESCRIPTION="Ubuntu 16.04.1 LTS"

$ varnishd -V
varnishd (varnish-5.0.0 revision 99d036f)
Copyright (c) 2006 Verdens Gang AS
Copyright (c) 2006-2015 Varnish Software AS
```
