### PR TITLE
Add support for -j varnishd option in reload-vcl

### DIFF
--- a/debian/reload-vcl
+++ b/debian/reload-vcl
@@ -87,7 +87,7 @@ done
 # Extract the -f and the -T option, and (try to) ensure that the
 # management interface is on the form hostname:address.
 OPTIND=1
-while getopts a:b:CdFf:g:h:i:l:M:n:P:p:S:s:T:t:u:Vw: flag $DAEMON_OPTS
+while getopts j:a:b:CdFf:g:h:i:l:M:n:P:p:S:s:T:t:u:Vw: flag $DAEMON_OPTS
 do
     case $flag in
 		f)

--- a/debian/reload-vcl
+++ b/debian/reload-vcl
@@ -87,7 +87,7 @@ done
 # Extract the -f and the -T option, and (try to) ensure that the
 # management interface is on the form hostname:address.
 OPTIND=1
-while getopts j:a:b:CdFf:g:h:i:l:M:n:P:p:S:s:T:t:u:Vw: flag $DAEMON_OPTS
+while getopts a:b:CdFf:g:h:i:j:l:M:n:P:p:S:s:T:t:u:Vw: flag $DAEMON_OPTS
 do
     case $flag in
 		f)


### PR DESCRIPTION
Just add's the -j option when checking $DAEMON_OPTS. Currently if you have -j set in /etc/defaults/varnish you get the following error:

> Illegal option -j
> Management port disabled. $DAEMON_OPTS must contain '-T hostname:port'