### PR TITLE
Prefix vcl_label to avoid invalid first character

### DIFF
--- a/debian/reload-vcl
+++ b/debian/reload-vcl
@@ -42,9 +42,9 @@ msg_secret_not_there="Error: Secret file %s does not exist\n"
 if [ -f /proc/sys/kernel/random/uuid ]
 then
     uuid=$(cat /proc/sys/kernel/random/uuid)
-    vcl_label="${LOGNAME}${LOGNAME:+_}${uuid}"
+    vcl_label="vcl_${LOGNAME}${LOGNAME:+_}${uuid}"
 else
-    vcl_label="$($date +${LOGNAME}${LOGNAME:+_}%s-%N)"
+    vcl_label="vcl_$($date +${LOGNAME}${LOGNAME:+_}%s-%N)"
 fi
 
 # Load defaults file


### PR DESCRIPTION
Should fix #51 