### PR TITLE
Add in warmup time in reload-vcl scripts

### DIFF
--- a/debian/reload-vcl
+++ b/debian/reload-vcl
@@ -52,10 +52,10 @@ if [ -f "$defaults" ]
 then
     if [ -r "$defaults" ]
     then
-	. "$defaults"
+        . "$defaults"
     else
-	printf >&2 "$msg_defaults_not_readable" $defaults
-	exit 1
+        printf >&2 "$msg_defaults_not_readable" $defaults
+    exit 1
     fi
 else
     printf >&2 "$msg_defaults_not_there" $defaults
@@ -66,20 +66,20 @@ fi
 while getopts hcq flag
 do
     case $flag in
-	h)
-	    printf >&2 "$msg_usage"
-	    exit 0
-	    ;;
-	c)
-	    compile_only=1
-	    ;;
-	q)
-	    quiet=1
-	    ;;
-	*)
-	    printf >&2 "$msg_usage\n"
-	    exit 1
-	    ;;
+    h)
+        printf >&2 "$msg_usage"
+        exit 0
+        ;;
+    c)
+        compile_only=1
+        ;;
+    q)
+        quiet=1
+        ;;
+    *)
+        printf >&2 "$msg_usage\n"
+        exit 1
+        ;;
     esac
 done
 
@@ -90,23 +90,25 @@ OPTIND=1
 while getopts a:b:CdFf:g:h:i:j:l:M:n:P:p:S:s:T:t:u:Vw: flag $DAEMON_OPTS
 do
     case $flag in
-		f)
-			if [ -f "$OPTARG" ]; then
-				vcl_file="$OPTARG"
-			fi
-			;;
-		T)
-			if [ -n "$OPTARG" -a "$OPTARG" != "${OPTARG%%:*}" ]
-			then
-				mgmt_interface="$OPTARG"
-			fi
-			;;
-		S)
-			secret="$OPTARG"
-			;;
+        f)
+            if [ -f "$OPTARG" ]; then
+                vcl_file="$OPTARG"
+            fi
+            ;;
+        T)
+            if [ -n "$OPTARG" -a "$OPTARG" != "${OPTARG%%:*}" ]
+            then
+                mgmt_interface="$OPTARG"
+            fi
+            ;;
+        S)
+            secret="$OPTARG"
+            ;;
     esac
 done
 
+# Get warmup time from defaults or use 0 warmup
+warmup_time=${WARMUP_TIME:-0}
 
 # Sanity checks
 if [ ! -x "$varnishadm" ]
@@ -129,15 +131,15 @@ fi
 
 # Check secret file
 if [ -f "$secret" ]
-	then
-	if [ ! -r "$secret" ]
-	then
-		printf >&2 "$msg_secret_not_readable" $secret
-		exit 1
-	fi
+    then
+    if [ ! -r "$secret" ]
+    then
+        printf >&2 "$msg_secret_not_readable" $secret
+        exit 1
+    fi
 else
-	printf >&2 "$msg_secret_not_there" $secret
-	exit 1
+    printf >&2 "$msg_secret_not_there" $secret
+    exit 1
 fi
 
 logfile=$($tempfile -n /tmp/$vcl_label)
@@ -147,15 +149,16 @@ if $varnishadm -T $mgmt_interface -S ${secret} vcl.load $vcl_label $vcl_file
 then
     if [ -n "$compile_only" ]
     then
-	printf "$msg_compile_only" $varnishadm $mgmt_interface $vcl_label
+        printf "$msg_compile_only" $varnishadm $mgmt_interface $vcl_label
     else
-	if $varnishadm -T $mgmt_interface -S ${secret} vcl.use $vcl_label
-	then
-	    printf "$msg_use_ok" $vcl_label
-	else
-	    printf "$msg_use_failed" $vcl_label
-	    exitstatus=1
-	fi
+        sleep $warmup_time
+        if $varnishadm -T $mgmt_interface -S ${secret} vcl.use $vcl_label
+        then
+            printf "$msg_use_ok" $vcl_label
+        else
+            printf "$msg_use_failed" $vcl_label
+            exitstatus=1
+        fi
     fi
 else
     printf "$msg_compile_failed" $vcl_label $vcl_file

--- a/debian/varnish.default
+++ b/debian/varnish.default
@@ -10,7 +10,7 @@
 # Should we start varnishd at boot?  Set to "no" to disable.
 START=yes
 
-# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.us
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.use
 # This is useful when backend probe definitions need some time before declaring
 # configured backends healthy, to avoid routing traffic to a non-healthy backend.
 #WARMUP_TIME=0

--- a/debian/varnish.default
+++ b/debian/varnish.default
@@ -10,6 +10,11 @@
 # Should we start varnishd at boot?  Set to "no" to disable.
 START=yes
 
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.us
+# This is useful when backend probe definitions need some time before declaring
+# configured backends healthy, to avoid routing traffic to a non-healthy backend.
+#WARMUP_TIME=0
+
 # Maximum number of open files (for ulimit -n)
 NFILES=131072
 
@@ -23,4 +28,3 @@ DAEMON_OPTS="-a :6081 \
              -f /etc/varnish/default.vcl \
              -S /etc/varnish/secret \
              -s malloc,256m"
-

--- a/debian/varnish.service
+++ b/debian/varnish.service
@@ -17,6 +17,11 @@ LimitMEMLOCK=82000
 # Maximum size of the corefile.
 LimitCORE=infinity
 
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.us
+# This is useful when backend probe definitions need some time before declaring
+# configured backends healthy, to avoid routing traffic to a non-healthy backend.
+#WARMUP_TIME=0
+
 ExecStart=/usr/sbin/varnishd -a :6081 -T localhost:6082 -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,256m
 ExecReload=/usr/share/varnish/reload-vcl
 

--- a/debian/varnish.service
+++ b/debian/varnish.service
@@ -17,7 +17,7 @@ LimitMEMLOCK=82000
 # Maximum size of the corefile.
 LimitCORE=infinity
 
-# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.us
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.use
 # This is useful when backend probe definitions need some time before declaring
 # configured backends healthy, to avoid routing traffic to a non-healthy backend.
 #WARMUP_TIME=0

--- a/redhat/varnish.params
+++ b/redhat/varnish.params
@@ -4,6 +4,11 @@
 # Set this to 1 to make systemd reload try to switch VCL without restart.
 RELOAD_VCL=1
 
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.us
+# This is useful when backend probe definitions need some time before declaring
+# configured backends healthy, to avoid routing traffic to a non-healthy backend.
+#WARMUP_TIME=0
+
 # Main configuration file. You probably want to change it.
 VARNISH_VCL_CONF=/etc/varnish/default.vcl
 

--- a/redhat/varnish.params
+++ b/redhat/varnish.params
@@ -4,7 +4,7 @@
 # Set this to 1 to make systemd reload try to switch VCL without restart.
 RELOAD_VCL=1
 
-# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.us
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.use
 # This is useful when backend probe definitions need some time before declaring
 # configured backends healthy, to avoid routing traffic to a non-healthy backend.
 #WARMUP_TIME=0

--- a/redhat/varnish.service
+++ b/redhat/varnish.service
@@ -23,6 +23,11 @@ LimitMEMLOCK=82000
 # Maximum size of the corefile.
 LimitCORE=infinity
 
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.us
+# This is useful when backend probe definitions need some time before declaring
+# configured backends healthy, to avoid routing traffic to a non-healthy backend.
+#WARMUP_TIME=0
+
 EnvironmentFile=/etc/varnish/varnish.params
 
 Type=forking

--- a/redhat/varnish.service
+++ b/redhat/varnish.service
@@ -23,11 +23,6 @@ LimitMEMLOCK=82000
 # Maximum size of the corefile.
 LimitCORE=infinity
 
-# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.us
-# This is useful when backend probe definitions need some time before declaring
-# configured backends healthy, to avoid routing traffic to a non-healthy backend.
-#WARMUP_TIME=0
-
 EnvironmentFile=/etc/varnish/varnish.params
 
 Type=forking

--- a/redhat/varnish.sysconfig
+++ b/redhat/varnish.sysconfig
@@ -23,7 +23,7 @@ NPROCS="unlimited"
 # VARNISH_ADMIN_LISTEN_PORT, VARNISH_SECRET_FILE.
 RELOAD_VCL=1
 
-# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.us
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.use
 # This is useful when backend probe definitions need some time before declaring
 # configured backends healthy, to avoid routing traffic to a non-healthy backend.
 #WARMUP_TIME=0

--- a/redhat/varnish.sysconfig
+++ b/redhat/varnish.sysconfig
@@ -23,6 +23,11 @@ NPROCS="unlimited"
 # VARNISH_ADMIN_LISTEN_PORT, VARNISH_SECRET_FILE.
 RELOAD_VCL=1
 
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.us
+# This is useful when backend probe definitions need some time before declaring
+# configured backends healthy, to avoid routing traffic to a non-healthy backend.
+#WARMUP_TIME=0
+
 # Main configuration file.
 VARNISH_VCL_CONF=/etc/varnish/default.vcl
 #

--- a/redhat/varnish_reload_vcl
+++ b/redhat/varnish_reload_vcl
@@ -38,6 +38,9 @@ if [ -z "$VARNISH_VCL_CONF" ]; then
 	. /etc/sysconfig/varnish
 fi
 
+# Get warmup time from defaults or use 0 warmup
+WARMUP=${WARMUP_TIME:-0}
+
 $debug && print_debug
 
 # Check configuration
@@ -103,6 +106,10 @@ else
 	echo "$VARNISHADM vcl.load failed"
 	exit 1
 fi
+
+# Wait before vcl.use if WARMUP > 0
+# Used if backend probes require some time to set backends healthy
+sleep $WARMUP
 
 if $VARNISHADM vcl.use $new_config; then
 	$debug && echo "$VARNISHADM vcl.use succeded"


### PR DESCRIPTION
Work on GH Issue #61. Implement a warmup time to let certain
systems wait for varnish probes to set backends healthy before
setting newly loaded vcl active.