### PR TITLE
Comply with varnishd commit

### DIFF
--- a/redhat/varnish_reload_vcl
+++ b/redhat/varnish_reload_vcl
@@ -76,7 +76,7 @@ fi
 VARNISHADM="varnishadm $secret -T $VARNISH_ADMIN_LISTEN_ADDRESS:$VARNISH_ADMIN_LISTEN_PORT"
 
 # Now do the real work
-new_config="reload_$(date +%FT%H:%M:%S)"
+new_config="reload_$(date +%FT%H%M%S)"
 
 # Check if we are able to connect at all
 if $VARNISHADM vcl.list > /dev/null; then


### PR DESCRIPTION
https://github.com/varnishcache/varnish-cache/commit/169e162
"Enforce that VCL names must be C-language identifiers"

... which means we will no longer get ISO 8601 style names :-/