### PR TITLE
vcl reload warmup fix take 2.

### DIFF
--- a/debian/reload-vcl
+++ b/debian/reload-vcl
@@ -107,6 +107,8 @@ do
     esac
 done
 
+# Get warmup time from defaults or use 0 warmup
+warmup_time=${WARMUP_TIME:-0}
 
 # Sanity checks
 if [ ! -x "$varnishadm" ]
@@ -149,6 +151,7 @@ then
     then
 	printf "$msg_compile_only" $varnishadm $mgmt_interface $vcl_label
     else
+    sleep $warmup_time
 	if $varnishadm -T $mgmt_interface -S ${secret} vcl.use $vcl_label
 	then
 	    printf "$msg_use_ok" $vcl_label

--- a/debian/varnish.default
+++ b/debian/varnish.default
@@ -10,6 +10,11 @@
 # Should we start varnishd at boot?  Set to "no" to disable.
 START=yes
 
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.use
+# This is useful when backend probe definitions need some time before declaring
+# configured backends healthy, to avoid routing traffic to a non-healthy backend.
+#WARMUP_TIME=0
+
 # Maximum number of open files (for ulimit -n)
 NFILES=131072
 

--- a/debian/varnish.service
+++ b/debian/varnish.service
@@ -17,6 +17,11 @@ LimitMEMLOCK=82000
 # Maximum size of the corefile.
 LimitCORE=infinity
 
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.use
+# This is useful when backend probe definitions need some time before declaring
+# configured backends healthy, to avoid routing traffic to a non-healthy backend.
+#WARMUP_TIME=0
+
 ExecStart=/usr/sbin/varnishd -a :6081 -T localhost:6082 -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,256m
 ExecReload=/usr/share/varnish/reload-vcl
 

--- a/redhat/varnish.params
+++ b/redhat/varnish.params
@@ -4,6 +4,11 @@
 # Set this to 1 to make systemd reload try to switch VCL without restart.
 RELOAD_VCL=1
 
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.use
+# This is useful when backend probe definitions need some time before declaring
+# configured backends healthy, to avoid routing traffic to a non-healthy backend.
+#WARMUP_TIME=0
+
 # Main configuration file. You probably want to change it.
 VARNISH_VCL_CONF=/etc/varnish/default.vcl
 

--- a/redhat/varnish.sysconfig
+++ b/redhat/varnish.sysconfig
@@ -23,6 +23,11 @@ NPROCS="unlimited"
 # VARNISH_ADMIN_LISTEN_PORT, VARNISH_SECRET_FILE.
 RELOAD_VCL=1
 
+# Set WARMUP_TIME to force a delay in reload-vcl between vcl.load and vcl.use
+# This is useful when backend probe definitions need some time before declaring
+# configured backends healthy, to avoid routing traffic to a non-healthy backend.
+#WARMUP_TIME=0
+
 # Main configuration file.
 VARNISH_VCL_CONF=/etc/varnish/default.vcl
 #

--- a/redhat/varnish_reload_vcl
+++ b/redhat/varnish_reload_vcl
@@ -38,6 +38,9 @@ if [ -z "$VARNISH_VCL_CONF" ]; then
 	. /etc/sysconfig/varnish
 fi
 
+# Get warmup time from defaults or use 0 warmup
+WARMUP=${WARMUP_TIME:-0}
+
 $debug && print_debug
 
 # Check configuration
@@ -103,6 +106,10 @@ else
 	echo "$VARNISHADM vcl.load failed"
 	exit 1
 fi
+
+# Wait before vcl.use if WARMUP > 0
+# Used if backend probes require some time to set backends healthy
+sleep $WARMUP
 
 if $VARNISHADM vcl.use $new_config; then
 	$debug && echo "$VARNISHADM vcl.use succeded"


### PR DESCRIPTION
Work on GH Issue #61. Implement a warmup time to let certain
systems wait for varnish probes to set backends healthy before
setting newly loaded vcl active.

@Dridi care to check again?