### PR TITLE
Move things from varnish-devel to varnish

### DIFF
--- a/redhat/varnish.spec
+++ b/redhat/varnish.spec
@@ -191,7 +191,6 @@ rm -rf %{buildroot}
 %{_libdir}/pkgconfig/varnishapi.pc
 %{_datadir}/varnish/vmodtool*
 %{_datadir}/aclocal/*
-%doc LICENSE
 
 
 %pre

--- a/redhat/varnish.spec
+++ b/redhat/varnish.spec
@@ -156,6 +156,8 @@ rm -rf %{buildroot}
 %{_mandir}/man3/*.3*
 %{_mandir}/man7/*.7*
 %{_docdir}/varnish/
+%{_datadir}/varnish
+%exclude %{_datadir}/varnish/vmodtool*
 %doc doc/html
 %doc doc/changes*.html
 %dir %{_sysconfdir}/varnish/
@@ -187,8 +189,8 @@ rm -rf %{buildroot}
 %dir %{_includedir}/varnish
 %{_includedir}/varnish/*
 %{_libdir}/pkgconfig/varnishapi.pc
-/usr/share/varnish
-/usr/share/aclocal
+%{_datadir}/varnish/vmodtool*
+%{_datadir}/aclocal/*
 %doc LICENSE
 
 


### PR DESCRIPTION
The `/usr/share/varnish/vcl` tree is the second location where Varnish looks up relative VCL files by default. This is where you'd expect other packages to install VCL files.

For reference:

https://github.com/varnishcache/varnish-cache/blob/varnish-5.1.0/varnish.m4#L373-L374
https://github.com/varnishcache/varnish-cache/blob/varnish-5.1.0/varnish.m4#L401-L412
https://github.com/varnishcache/varnish-cache/blob/varnish-5.1.0/varnish.m4#L340-L354