### PR TITLE
Unified reload script

### DIFF
--- a/varnishreload
+++ b/varnishreload
@@ -161,7 +161,7 @@ fi
 
 RELOAD_NAME=$(vcl_reload_name)
 
-varnishadm vcl.load "$RELOAD_NAME" "$VCL_FILE"
+varnishadm vcl.load "$RELOAD_NAME" "$VCL_FILE" warm
 
 test -n "$WARMUP" && sleep "$WARMUP"
 

--- a/varnishreload
+++ b/varnishreload
@@ -39,7 +39,7 @@ vcl_file() {
 }
 
 vcl_active_name() {
-	if ! VCL_LIST="$(varnishadm vcl.lists)"
+	if ! VCL_LIST="$(varnishadm vcl.list)"
 	then
 		fail "failed to get the active VCL name"
 	fi

--- a/varnishreload
+++ b/varnishreload
@@ -75,6 +75,28 @@ vcl_active_file() {
 	vcl_file "$VCL_NAME"
 }
 
+vcl_reload_match() {
+	awk '$1 == "available" && $NF ~ /^reload_[0-9]{8}_[0-9]{6}$/'" {$1}"
+}
+
+vcl_reload_count() {
+	VCL_LIST="$(varnishadm vcl.list)" ||
+	fail "failed to count available reload VCLs"
+
+	echo "$VCL_LIST" |
+	vcl_reload_match print |
+	sed '=;d' |
+	tail -1
+}
+
+vcl_reload_oldest() {
+	VCL_LIST="$(varnishadm vcl.list)" ||
+	fail "failed to get the oldest reload VCLs"
+
+	echo "$VCL_LIST" |
+	vcl_reload_match 'print $NF; exit'
+}
+
 vcl_reload_name() {
 	printf "reload_%s" "$(date +%Y%m%d_%H%M%S)"
 }
@@ -120,3 +142,19 @@ varnishadm vcl.load "$RELOAD_NAME" "$VCL_FILE"
 test -n "$WARMUP" && sleep "$WARMUP"
 
 varnishadm vcl.use  "$RELOAD_NAME"
+
+safe_test() {
+	test -z "$1" && return 1
+	test "$@"
+}
+
+safe_test "$MAXIMUM" -ge 0 || exit 0
+
+while true
+do
+	COUNT=$(vcl_reload_count)
+	safe_test "$COUNT" -gt "$MAXIMUM" || exit 0
+	OLDEST=$(vcl_reload_oldest)
+	varnishadm vcl.discard "$OLDEST" >/dev/null
+	echo "VCL '$OLDEST' was discarded"
+done

--- a/varnishreload
+++ b/varnishreload
@@ -53,7 +53,7 @@ vcl_file() {
 	fail "failed to get the VCL file name"
 
 	echo "$VCL_SHOW" |
-	awk 'NR == 1 {print $NF}'
+	awk '$1 == "//" && $2 == "VCL.SHOW" {print $NF; exit}'
 }
 
 vcl_active_name() {

--- a/varnishreload
+++ b/varnishreload
@@ -111,7 +111,7 @@ vcl_active_file() {
 }
 
 vcl_reload_match() {
-	awk '$1 == "available" && $NF ~ /^reload_[0-9]{8}_[0-9]{6}$/'" {$1}"
+	awk '$1 == "available" && $NF ~ /^reload_[0-9]+_[0-9]+$/'" {$1}"
 }
 
 vcl_reload_count() {

--- a/varnishreload
+++ b/varnishreload
@@ -126,7 +126,7 @@ find_vcl_file() {
 find_vcl_reloads() {
 	awk_vcl_list 'NF == 4 &&
 		$1 == "available" &&
-		$4 ~ /^reload_[0-9]+_[0-9]+$/ {print $4}'
+		$4 ~ /^reload_[0-9]+_[0-9]+_[0-9]+$/ {print $4}'
 }
 
 while getopts hl:m:n:w: OPT

--- a/varnishreload
+++ b/varnishreload
@@ -86,7 +86,7 @@ fail() {
 }
 
 vcl_file() {
-	VCL_SHOW="$(varnishadm vcl.show -v "$1")" ||
+	VCL_SHOW=$(varnishadm vcl.show -v "$1") ||
 	fail "failed to get the VCL file name"
 
 	echo "$VCL_SHOW" |
@@ -94,7 +94,7 @@ vcl_file() {
 }
 
 vcl_active_name() {
-	VCL_LIST="$(varnishadm vcl.list)" ||
+	VCL_LIST=$(varnishadm vcl.list) ||
 	fail "failed to get the active VCL name"
 
 	echo "$VCL_LIST" |
@@ -112,7 +112,7 @@ vcl_reload_match() {
 }
 
 vcl_reload_count() {
-	VCL_LIST="$(varnishadm vcl.list)" ||
+	VCL_LIST=$(varnishadm vcl.list) ||
 	fail "failed to count available reload VCLs"
 
 	echo "$VCL_LIST" |
@@ -122,7 +122,7 @@ vcl_reload_count() {
 }
 
 vcl_reload_oldest() {
-	VCL_LIST="$(varnishadm vcl.list)" ||
+	VCL_LIST=$(varnishadm vcl.list) ||
 	fail "failed to get the oldest reload VCL"
 
 	echo "$VCL_LIST" |

--- a/varnishreload
+++ b/varnishreload
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+set -e
+set -u
+
+WORK_DIR=
+VCL_FILE=
+WARMUP=
+
+varnishadm() {
+	if ! OUTPUT="$(command varnishadm -n "$WORK_DIR" -- "$@" 2>&1)"
+	then
+		echo "Command: varnishadm -n '$WORK_DIR' -- $*"
+		echo
+		echo "$OUTPUT"
+		echo
+		exit 1
+	fi >&2
+	echo "$OUTPUT"
+}
+
+fail() {
+	echo "Error: $*" >&2
+	exit 1
+}
+
+vcl_count() {
+	varnishadm vcl.list |
+	awk "BEGIN {n=0} \$NF == \"$1\" {n=n+1} END {print n}"
+}
+
+vcl_file() {
+	if ! VCL_SHOW="$(varnishadm vcl.show -v "$1")"
+	then
+		fail "failed to get the VCL file name"
+	fi
+	echo "$VCL_SHOW" |
+	awk 'NR == 1 {print $NF}'
+}
+
+vcl_active_name() {
+	if ! VCL_LIST="$(varnishadm vcl.lists)"
+	then
+		fail "failed to get the active VCL name"
+	fi
+	echo "$VCL_LIST" |
+	awk '/^active/ {print $NF}'
+}
+
+vcl_active_file() {
+	set -e
+
+	VCL_NAME=$(vcl_active_name)
+	VCL_COUNT=$(vcl_count "$VCL_NAME")
+
+	# XXX: it can happen with a discard but I haven't checked whether it
+	#      actually messes with vcl.show (I suspect we don't need this).
+	test "$VCL_COUNT" -gt 1 &&
+	fail "more than one VCL named $VCL_NAME ($VCL_COUNT)"
+
+	vcl_file "$VCL_NAME"
+}
+
+vcl_reload_name() {
+	printf "reload_%s" "$(date +%Y%m%dT%H%M%S)"
+}
+
+# TODO: getopts for -n only, if any (probably without heavy-handed getopts)
+# TODO: get VCL_FILE from first (and only) non-opt argument, if any
+
+if [ -z "$VCL_FILE" ]
+then
+	VCL_FILE=$(vcl_active_file)
+
+	case $VCL_FILE in
+	/*) ;;
+	*) fail "active VCL file not found (got $VCL_FILE)" ;;
+	esac
+fi
+
+RELOAD_NAME=$(vcl_reload_name)
+
+varnishadm vcl.load "$RELOAD_NAME" "$VCL_FILE"
+# TODO: warmup pause
+varnishadm vcl.use  "$RELOAD_NAME"

--- a/varnishreload
+++ b/varnishreload
@@ -8,7 +8,7 @@ VCL_FILE=
 WARMUP=
 
 varnishadm() {
-	if ! OUTPUT="$(command varnishadm -n "$WORK_DIR" -- "$@" 2>&1)"
+	if ! OUTPUT=$(command varnishadm -n "$WORK_DIR" -- "$@" 2>&1)
 	then
 		echo "Command: varnishadm -n '$WORK_DIR' -- $*"
 		echo

--- a/varnishreload
+++ b/varnishreload
@@ -114,5 +114,7 @@ fi
 RELOAD_NAME=$(vcl_reload_name)
 
 varnishadm vcl.load "$RELOAD_NAME" "$VCL_FILE"
-# TODO: warmup pause
+
+test -n "$WARMUP" && sleep "$WARMUP"
+
 varnishadm vcl.use  "$RELOAD_NAME"

--- a/varnishreload
+++ b/varnishreload
@@ -10,14 +10,17 @@ WARMUP=
 SCRIPT="$0"
 
 usage() {
+	test $# -eq 1 &&
+	printf 'Error: %s.\n\n' "$1"
+
 	cat <<-EOF
-	Error: $1.
-
 	Usage: $SCRIPT [-m <maximum>] [-n <workdir>] [-w <warmup>] [<file>]
+	       $SCRIPT -h
 
-	Reload and use a VCL on a running Varnish instance. Options must be
-	specified in that order when used:
+	Reload and use a VCL on a running Varnish instance.
 
+	Available options:
+	-h           : show this help and exit
 	-m <maximum> : maximum number of available reloads to leave behind
 	-n <workdir> : for a different working directory for varnishd
 	-w <warmup>  : the waiting period between load and use operations
@@ -33,7 +36,7 @@ usage() {
 	Afterwards available VCLs created by this script are discarded until
 	<maximum> are left, unless it was empty or undefined.
 	EOF
-	exit 1
+	exit $#
 }
 
 varnishadm() {
@@ -101,28 +104,20 @@ vcl_reload_name() {
 	printf "reload_%s" "$(date +%Y%m%d_%H%M%S)"
 }
 
-if [ $# -gt 0 ] && [ "$1" = -m ]
-then
-	test $# -gt 1 || usage "missing argument to -m"
-	MAXIMUM="$2"
-	shift 2
-fi
+while getopts hm:n:w: OPT
+do
+	case $OPT in
+	h) usage ;;
+	m) MAXIMUM=$OPTARG ;;
+	n) WORK_DIR=$OPTARG ;;
+	w) WARMUP=$OPTARG ;;
+	*) usage "wrong usage" >&2 ;;
+	esac
+done
 
-if [ $# -gt 0 ] && [ "$1" = -n ]
-then
-	test $# -gt 1 || usage "missing argument to -n"
-	WORK_DIR="$2"
-	shift 2
-fi
+shift $((OPTIND - 1))
 
-if [ $# -gt 0 ] && [ "$1" = -w ]
-then
-	test $# -gt 1 || usage "missing argument to -w"
-	WARMUP="$2"
-	shift 2
-fi
-
-test $# -gt 1 && usage "too many arguments"
+test $# -gt 1 && usage "too many arguments" >&2
 test $# -eq 1 && VCL_FILE="$1"
 
 if [ -z "$VCL_FILE" ]

--- a/varnishreload
+++ b/varnishreload
@@ -115,6 +115,7 @@ find_vcl_file() {
 
 	echo "$VCL_SHOW" |
 	awk '$1 == "//" && $2 == "VCL.SHOW" {print; exit}' | {
+		# all this ceremony to handle blanks in FILE
 		read -r DELIM VCL_SHOW INDEX SIZE FILE
 		echo "$FILE"
 	}

--- a/varnishreload
+++ b/varnishreload
@@ -94,7 +94,7 @@ vcl_reload_count() {
 
 vcl_reload_oldest() {
 	VCL_LIST="$(varnishadm vcl.list)" ||
-	fail "failed to get the oldest reload VCLs"
+	fail "failed to get the oldest reload VCL"
 
 	echo "$VCL_LIST" |
 	vcl_reload_match 'print $NF; exit'

--- a/varnishreload
+++ b/varnishreload
@@ -49,19 +49,17 @@ fail() {
 }
 
 vcl_file() {
-	if ! VCL_SHOW="$(varnishadm vcl.show -v "$1")"
-	then
-		fail "failed to get the VCL file name"
-	fi
+	VCL_SHOW="$(varnishadm vcl.show -v "$1")" ||
+	fail "failed to get the VCL file name"
+
 	echo "$VCL_SHOW" |
 	awk 'NR == 1 {print $NF}'
 }
 
 vcl_active_name() {
-	if ! VCL_LIST="$(varnishadm vcl.list)"
-	then
-		fail "failed to get the active VCL name"
-	fi
+	VCL_LIST="$(varnishadm vcl.list)" ||
+	fail "failed to get the active VCL name"
+
 	echo "$VCL_LIST" |
 	awk '$1 == "active" {print $NF}'
 }

--- a/varnishreload
+++ b/varnishreload
@@ -1,4 +1,30 @@
 #!/bin/sh
+#
+# Copyright (c) 2006-2017 Varnish Software AS
+# All rights reserved.
+#
+# Author: Dridi Boukelmoune <dridi.boukelmoune@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
 
 set -e
 set -u

--- a/varnishreload
+++ b/varnishreload
@@ -110,11 +110,14 @@ find_label_ref() {
 }
 
 find_vcl_file() {
-	VCL_SOURCE=$(varnishadm vcl.show -v "$VCL_NAME") ||
+	VCL_SHOW=$(varnishadm vcl.show -v "$VCL_NAME") ||
 	fail "failed to get the VCL file name"
 
-	echo "$VCL_SOURCE" |
-	awk '$1 == "//" && $2 == "VCL.SHOW" {print $5; exit}'
+	echo "$VCL_SHOW" |
+	awk '$1 == "//" && $2 == "VCL.SHOW" {print; exit}' | {
+		read -r DELIM VCL_SHOW INDEX SIZE FILE
+		echo "$FILE"
+	}
 }
 
 find_vcl_reloads() {

--- a/varnishreload
+++ b/varnishreload
@@ -48,11 +48,6 @@ fail() {
 	exit 1
 }
 
-vcl_count() {
-	varnishadm vcl.list |
-	awk "BEGIN {n=0} \$NF == \"$1\" {n=n+1} END {print n}"
-}
-
 vcl_file() {
 	if ! VCL_SHOW="$(varnishadm vcl.show -v "$1")"
 	then
@@ -73,15 +68,7 @@ vcl_active_name() {
 
 vcl_active_file() {
 	set -e
-
 	VCL_NAME=$(vcl_active_name)
-	VCL_COUNT=$(vcl_count "$VCL_NAME")
-
-	# XXX: it can happen with a discard but I haven't checked whether it
-	#      actually messes with vcl.show (I suspect we don't need this).
-	test "$VCL_COUNT" -gt 1 &&
-	fail "more than one VCL named $VCL_NAME ($VCL_COUNT)"
-
 	vcl_file "$VCL_NAME"
 }
 

--- a/varnishreload
+++ b/varnishreload
@@ -48,11 +48,14 @@ usage() {
 	Available options:
 	-h           : show this help and exit
 	-m <maximum> : maximum number of available reloads to leave behind
-	-n <workdir> : for a different working directory for varnishd
-	-w <warmup>  : the waiting period between load and use operations
+	-n <workdir> : specify the name or directory for the varnishd instance
+	-w <warmup>  : the number of seconds between load and use operations
 
 	When <file> is empty or missing, the active VCL's file is used but
-	will fail if the active VCL wasn't loaded from a file.
+	will fail if the active VCL wasn't loaded from a file. The <file>,
+	when specified, is passed as-is to the vcl.load command. Refer to
+	the varnishd manual regarding the handling of absolute or relative
+	paths.
 
 	Upon success, the name of the loaded VCL is constructed from the
 	current date and time, for example:

--- a/varnishreload
+++ b/varnishreload
@@ -84,8 +84,22 @@ vcl_reload_name() {
 	printf "reload_%s" "$(date +%Y%m%dT%H%M%S)"
 }
 
-# TODO: getopts for -n only, if any (probably without heavy-handed getopts)
-# TODO: get VCL_FILE from first (and only) non-opt argument, if any
+if [ $# -gt 0 ] && [ "$1" = -n ]
+then
+	test $# -gt 1 || usage "missing argument to -n"
+	WORK_DIR="$2"
+	shift 2
+fi
+
+if [ $# -gt 0 ] && [ "$1" = -w ]
+then
+	test $# -gt 1 || usage "missing argument to -w"
+	WARMUP="$2"
+	shift 2
+fi
+
+test $# -gt 1 && usage "too many arguments"
+test $# -eq 1 && VCL_FILE="$1"
 
 if [ -z "$VCL_FILE" ]
 then

--- a/varnishreload
+++ b/varnishreload
@@ -6,6 +6,25 @@ set -u
 WORK_DIR=
 VCL_FILE=
 WARMUP=
+SCRIPT="$0"
+
+usage() {
+	cat <<-EOF
+	Error: $1.
+
+	Usage: $SCRIPT [-n <workdir>] [-w <warmup>] [<file>]
+
+	Reload and use a VCL on a running Varnish instance. Options must be
+	specified in that order when used:
+
+	-n <workdir> : for a different working directory for varnishd
+	-w <warmup>  : the waiting period between load and use operations
+
+	When <file> is empty or missing, the active VCL's file is used but
+	will fail if the active VCL wasn't loaded from a file.
+	EOF
+	exit 1
+}
 
 varnishadm() {
 	if ! OUTPUT=$(command varnishadm -n "$WORK_DIR" -- "$@" 2>&1)

--- a/varnishreload
+++ b/varnishreload
@@ -108,7 +108,7 @@ active_vcl() {
 }
 
 find_label_ref() {
-	awk_vcl_list '$4 == "'"$VCL_LABEL"'" {print $6}'
+	awk_vcl_list '$4 == "'"$VCL_LABEL"'" && $5 == "->" {print $6}'
 }
 
 find_vcl_file() {

--- a/varnishreload
+++ b/varnishreload
@@ -30,9 +30,12 @@ set -e
 set -u
 
 MAXIMUM=
-WORK_DIR=
 VCL_FILE=
+VCL_LABEL=
+VCL_NAME=
 WARMUP=
+WORK_DIR=
+
 SCRIPT="$0"
 
 usage() {
@@ -40,22 +43,26 @@ usage() {
 	printf 'Error: %s.\n\n' "$1"
 
 	cat <<-EOF
-	Usage: $SCRIPT [-m <maximum>] [-n <workdir>] [-w <warmup>] [<file>]
+	Usage: $SCRIPT [-l <label>] [-m <max>] [-n <workdir>] [-w <warmup>] [<file>]
 	       $SCRIPT -h
 
 	Reload and use a VCL on a running Varnish instance.
 
 	Available options:
 	-h           : show this help and exit
-	-m <maximum> : maximum number of available reloads to leave behind
+	-l <label>   : name of the VCL label to reload
+	-m <max>     : maximum number of available reloads to leave behind
 	-n <workdir> : specify the name or directory for the varnishd instance
 	-w <warmup>  : the number of seconds between load and use operations
 
-	When <file> is empty or missing, the active VCL's file is used but
-	will fail if the active VCL wasn't loaded from a file. The <file>,
-	when specified, is passed as-is to the vcl.load command. Refer to
-	the varnishd manual regarding the handling of absolute or relative
-	paths.
+	When <label> is empty or missing, the active VCL is reloaded. If the
+	reloaded VCL is a label, the underlying VCL program is reloaded, and
+	the label is updated to reference the new program.
+
+	When <file> is empty or missing, the selected VCL's file is used but
+	reload will fail if it wasn't loaded from a file. The <file>, when
+	specified, is passed as-is to the vcl.load command. Refer to the
+	varnishd manual regarding the handling of absolute or relative paths.
 
 	Upon success, the name of the loaded VCL is constructed from the
 	current date and time, for example:
@@ -63,7 +70,8 @@ usage() {
 	    $(vcl_reload_name)
 
 	Afterwards available VCLs created by this script are discarded until
-	<maximum> are left, unless it was empty or undefined.
+	<max> are left, unless it was empty or undefined. VCLs referenced by
+	a label aren't discarded.
 	EOF
 	exit $#
 }
@@ -75,7 +83,7 @@ varnishadm() {
 		echo
 		echo "$OUTPUT"
 		echo
-		exit 1
+		return 1
 	fi >&2
 	echo "$OUTPUT"
 }
@@ -85,61 +93,41 @@ fail() {
 	exit 1
 }
 
-vcl_file() {
-	VCL_SHOW=$(varnishadm vcl.show -v "$1") ||
-	fail "failed to get the VCL file name"
-
-	echo "$VCL_SHOW" |
-	awk '$1 == "//" && $2 == "VCL.SHOW" {print; exit}' | {
-		read DELIM VCL_SHOW INDEX SIZE FILE
-		echo "$FILE"
-	}
-}
-
-vcl_active_name() {
-	VCL_LIST=$(varnishadm vcl.list) ||
-	fail "failed to get the active VCL name"
-
-	echo "$VCL_LIST" |
-	awk '$1 == "active" {print $NF}'
-}
-
-vcl_active_file() {
-	set -e
-	VCL_NAME=$(vcl_active_name)
-	vcl_file "$VCL_NAME"
-}
-
-vcl_reload_match() {
-	awk '$1 == "available" && $NF ~ /^reload_[0-9]+_[0-9]+$/'" {$1}"
-}
-
-vcl_reload_count() {
-	VCL_LIST=$(varnishadm vcl.list) ||
-	fail "failed to count available reload VCLs"
-
-	echo "$VCL_LIST" |
-	vcl_reload_match print |
-	sed '=;d' |
-	tail -1
-}
-
-vcl_reload_oldest() {
-	VCL_LIST=$(varnishadm vcl.list) ||
-	fail "failed to get the oldest reload VCL"
-
-	echo "$VCL_LIST" |
-	vcl_reload_match 'print $NF; exit'
-}
-
 vcl_reload_name() {
 	printf "reload_%s" "$(date +%Y%m%d_%H%M%S)"
 }
 
-while getopts hm:n:w: OPT
+awk_vcl_list() {
+	printf '%s' "$VCL_LIST" | awk "$@"
+}
+
+active_vcl() {
+	awk_vcl_list '$1 == "active" {print $4}'
+}
+
+find_label_ref() {
+	awk_vcl_list '$4 == "'"$VCL_LABEL"'" {print $6}'
+}
+
+find_vcl_file() {
+	VCL_SOURCE=$(varnishadm vcl.show -v "$VCL_NAME") ||
+	fail "failed to get the VCL file name"
+
+	echo "$VCL_SOURCE" |
+	awk '$1 == "//" && $2 == "VCL.SHOW" {print $5; exit}'
+}
+
+find_vcl_reloads() {
+	awk_vcl_list 'NF == 4 &&
+		$1 == "available" &&
+		$4 ~ /^reload_[0-9]+_[0-9]+$/ {print $4}'
+}
+
+while getopts hl:m:n:w: OPT
 do
 	case $OPT in
 	h) usage ;;
+	l) VCL_LABEL=$OPTARG ;;
 	m) MAXIMUM=$OPTARG ;;
 	n) WORK_DIR=$OPTARG ;;
 	w) WARMUP=$OPTARG ;;
@@ -152,36 +140,73 @@ shift $((OPTIND - 1))
 test $# -gt 1 && usage "too many arguments" >&2
 test $# -eq 1 && VCL_FILE="$1"
 
+VCL_LIST=$(varnishadm vcl.list) ||
+fail "failed to get the VCL list"
+
+if [ -z "$VCL_LABEL" ]
+then
+	VCL_NAME=$(active_vcl)
+	VCL_LABEL=$VCL_NAME
+	VCL_REF=$(find_label_ref)
+	if [ -n "$VCL_REF" ]
+	then
+		# active VCL is a label, swap
+		VCL_LABEL=$VCL_NAME
+		VCL_NAME=$VCL_REF
+	else
+		# not a label after all
+		VCL_LABEL=
+	fi
+else
+	VCL_NAME=$(find_label_ref)
+fi
+
+test -n "$VCL_NAME" ||
+fail "'$VCL_LABEL' is not a label"
+
 if [ -z "$VCL_FILE" ]
 then
-	VCL_FILE=$(vcl_active_file)
+	VCL_FILE=$(find_vcl_file)
 
 	case $VCL_FILE in
 	/*) ;;
-	*) fail "active VCL file not found (got $VCL_FILE)" ;;
+	*) fail "VCL file not found for $VCL_NAME (got $VCL_FILE)" ;;
 	esac
 fi
 
 RELOAD_NAME=$(vcl_reload_name)
 
-varnishadm vcl.load "$RELOAD_NAME" "$VCL_FILE"
+varnishadm vcl.load "$RELOAD_NAME" "$VCL_FILE" >/dev/null
+echo "VCL '$RELOAD_NAME' compiled"
 
 test -n "$WARMUP" && sleep "$WARMUP"
 
-varnishadm vcl.use  "$RELOAD_NAME"
+if [ -n "$VCL_LABEL" ]
+then
+	varnishadm vcl.label "$VCL_LABEL" "$RELOAD_NAME" >/dev/null
+	echo "VCL label '$VCL_LABEL' references '$RELOAD_NAME'"
+fi
 
-safe_test() {
-	test -z "$1" && return 1
-	test "$@"
-}
+if [ "$VCL_NAME" = "$(active_vcl)" ]
+then
+	varnishadm vcl.use "$RELOAD_NAME"
+fi
 
-safe_test "$MAXIMUM" -ge 0 || exit 0
+test -n "$MAXIMUM" || exit 0
+test "$MAXIMUM" -ge 0 || exit 0
 
-while true
+VCL_LIST=$(varnishadm vcl.list) ||
+fail "failed to refresh the VCL list"
+
+AVAILABLE=$(find_vcl_reloads | wc -l)
+DISCARDED=$((AVAILABLE - MAXIMUM))
+
+test "$DISCARDED" -gt 0 || exit 0
+
+find_vcl_reloads |
+head -n "$DISCARDED" |
+while read -r DISCARD_NAME
 do
-	COUNT=$(vcl_reload_count)
-	safe_test "$COUNT" -gt "$MAXIMUM" || exit 0
-	OLDEST=$(vcl_reload_oldest)
-	varnishadm vcl.discard "$OLDEST" >/dev/null
-	echo "VCL '$OLDEST' was discarded"
+	varnishadm vcl.discard "$DISCARD_NAME" >/dev/null
+	echo "VCL '$DISCARD_NAME' discarded"
 done

--- a/varnishreload
+++ b/varnishreload
@@ -94,7 +94,9 @@ fail() {
 }
 
 vcl_reload_name() {
-	printf "reload_%s" "$(date +%Y%m%d_%H%M%S)"
+	# NB: The PID compensates the lack of sub-second resolution.
+	# Varnish will vcl.list in chronological vcl.load order anyway.
+	printf "reload_%s" "$(date -u +%Y%m%d_%H%M%S_$$)"
 }
 
 awk_vcl_list() {

--- a/varnishreload
+++ b/varnishreload
@@ -22,6 +22,11 @@ usage() {
 
 	When <file> is empty or missing, the active VCL's file is used but
 	will fail if the active VCL wasn't loaded from a file.
+
+	Upon success, the name of the loaded VCL is constructed from the
+	current date and time, for example:
+
+	    $(vcl_reload_name)
 	EOF
 	exit 1
 }
@@ -81,7 +86,7 @@ vcl_active_file() {
 }
 
 vcl_reload_name() {
-	printf "reload_%s" "$(date +%Y%m%dT%H%M%S)"
+	printf "reload_%s" "$(date +%Y%m%d_%H%M%S)"
 }
 
 if [ $# -gt 0 ] && [ "$1" = -n ]

--- a/varnishreload
+++ b/varnishreload
@@ -63,7 +63,7 @@ vcl_active_name() {
 		fail "failed to get the active VCL name"
 	fi
 	echo "$VCL_LIST" |
-	awk '/^active/ {print $NF}'
+	awk '$1 == "active" {print $NF}'
 }
 
 vcl_active_file() {

--- a/varnishreload
+++ b/varnishreload
@@ -161,7 +161,7 @@ fi
 
 RELOAD_NAME=$(vcl_reload_name)
 
-varnishadm vcl.load "$RELOAD_NAME" "$VCL_FILE" warm
+varnishadm vcl.load "$RELOAD_NAME" "$VCL_FILE"
 
 test -n "$WARMUP" && sleep "$WARMUP"
 

--- a/varnishreload
+++ b/varnishreload
@@ -90,7 +90,10 @@ vcl_file() {
 	fail "failed to get the VCL file name"
 
 	echo "$VCL_SHOW" |
-	awk '$1 == "//" && $2 == "VCL.SHOW" {print $NF; exit}'
+	awk '$1 == "//" && $2 == "VCL.SHOW" {print; exit}' | {
+		read DELIM VCL_SHOW INDEX SIZE FILE
+		echo "$FILE"
+	}
 }
 
 vcl_active_name() {

--- a/varnishreload
+++ b/varnishreload
@@ -3,6 +3,7 @@
 set -e
 set -u
 
+MAXIMUM=
 WORK_DIR=
 VCL_FILE=
 WARMUP=
@@ -12,11 +13,12 @@ usage() {
 	cat <<-EOF
 	Error: $1.
 
-	Usage: $SCRIPT [-n <workdir>] [-w <warmup>] [<file>]
+	Usage: $SCRIPT [-m <maximum>] [-n <workdir>] [-w <warmup>] [<file>]
 
 	Reload and use a VCL on a running Varnish instance. Options must be
 	specified in that order when used:
 
+	-m <maximum> : maximum number of available reloads to leave behind
 	-n <workdir> : for a different working directory for varnishd
 	-w <warmup>  : the waiting period between load and use operations
 
@@ -27,6 +29,9 @@ usage() {
 	current date and time, for example:
 
 	    $(vcl_reload_name)
+
+	Afterwards available VCLs created by this script are discarded until
+	<maximum> are left, unless it was empty or undefined.
 	EOF
 	exit 1
 }
@@ -73,6 +78,13 @@ vcl_active_file() {
 vcl_reload_name() {
 	printf "reload_%s" "$(date +%Y%m%d_%H%M%S)"
 }
+
+if [ $# -gt 0 ] && [ "$1" = -m ]
+then
+	test $# -gt 1 || usage "missing argument to -m"
+	MAXIMUM="$2"
+	shift 2
+fi
 
 if [ $# -gt 0 ] && [ "$1" = -n ]
 then


### PR DESCRIPTION
⚠️ WORK IN PROGRESS ⚠️ 

Following offline discussions and observations made in #30, this is a new script that should work on all supported platforms. This isn't finished but if you have early comments, don't hesitate.

Goals:

- narrow scope: reload VCL from service manager
- self-contained: no coupling to /etc, only the `varnish-cli`
- limited interface
- simple defaults

Non goals:

- support platforms outside pkg-varnish-cache [1]
- support older Varnish versions [2]
- support existing scripts features
- handle all `varnishd` and `varnishadm` options

This will hopefully remove future problems akin to #35, #51, #61 and #64. The first prototype has seen limited testing.

[1] but I try to keep the script portable
[2] but if it can work, let's help it