### PR TITLE
Use dh-systemd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,8 @@ Build-Depends:
  libtool,
  pkg-config,
  python-docutils,
- python-sphinx
+ python-sphinx,
+ dh-systemd
 Vcs-Git:  git://github.com/varnishcache/pkg-varnish-cache.git
 Homepage: https://www.varnish-cache.org/
 Standards-Version: 3.9.6

--- a/debian/rules
+++ b/debian/rules
@@ -26,7 +26,7 @@ VMOD_ABI = $(shell printf '\#include "vrt.h"\nvarnishabi- VRT_MAJOR_VERSION . VR
 
 # Main build rule, leave everything to debhelper
 %:
-	dh $@ --parallel
+	dh $@ --parallel --with systemd
 
 ifeq (,$(filter test,$(LOCAL_BUILD_OPTIONS)))
 # Disable automated build tests


### PR DESCRIPTION
Adds a build dependency on dh-systemd
Uses the systemd add-on for `dh`

This should resolve #73 