### PR TITLE
Fix case where admin listen address is empty, and secret is set

### DIFF
--- a/redhat/varnish_reload_vcl
+++ b/redhat/varnish_reload_vcl
@@ -56,15 +56,17 @@ elif [ ! -s "$VARNISH_VCL_CONF" ]; then
 	echo "Eror: VCL config $VARNISH_VCL_CONF is unreadable or empty"
 	exit 2
 
-elif [ -z "$VARNISH_ADMIN_LISTEN_ADDRESS" ]; then
-	echo "Warning: VARNISH_ADMIN_LISTEN_ADDRESS is not set, using 127.0.0.1"
-	VARNISH_ADMIN_LISTEN_ADDRESS="127.0.0.1"
-
 elif [ -z "$VARNISH_ADMIN_LISTEN_PORT" ]; then
 	echo "Error: VARNISH_ADMIN_LISTEN_PORT is not set"
 	exit 2
+fi
 
-elif [ -z "$VARNISH_SECRET_FILE" ]; then
+if [ -z "$VARNISH_ADMIN_LISTEN_ADDRESS" ]; then
+	echo "Warning: VARNISH_ADMIN_LISTEN_ADDRESS is not set, using 127.0.0.1"
+	VARNISH_ADMIN_LISTEN_ADDRESS="127.0.0.1"
+fi
+
+if [ -z "$VARNISH_SECRET_FILE" ]; then
 	echo "Warning: VARNISH_SECRET_FILE is not set"
 	secret=""
 


### PR DESCRIPTION
Imagine all other options being valid, including having a secret file
set, but we've purposefully left VARNISH_ADMIN_LISTEN_ADDRESS as an
empty string.  (As we're want to do in a local testing VM, while
building tooling around Varnish.)

When we go issue a reload, it fails: "Authentication Required".

This patch ensures that VARNISH_SECRET_FILE is respected, even when we
allow a defaulting behavior for VARNISH_ADMIN_LISTEN_ADDRESS.