### PR TITLE
Doc fixes

### DIFF
--- a/debian/varnish.docs
+++ b/debian/varnish.docs
@@ -1,3 +1,4 @@
+README*
 doc/changes.rst
 # previously in varnish-doc
 doc/html

--- a/debian/varnish.examples
+++ b/debian/varnish.examples
@@ -1,1 +1,0 @@
-bin/varnishd/builtin.vcl

--- a/redhat/varnish.spec
+++ b/redhat/varnish.spec
@@ -127,6 +127,7 @@ rm -rf %{buildroot}
 %{_unitdir}/*
 %exclude %{_datadir}/%{name}/vmodtool*
 %exclude %{_datadir}/%{name}/vsctool*
+%doc README*
 %doc LICENSE
 %doc doc/html
 %doc doc/changes*.html


### PR DESCRIPTION
READMEs:
- Installing again the once-installed README.rst and README.packaging

VCLs:
- Installing the commented-out builtin.vcl to /etc/varnish, just like
the default.vcl
- Not installing these 2 anymore to /usr/share/doc/varnish
- A non-commented version of builtin.vcl is installed into
/usr/share/doc/varnish/examples.