### PR TITLE
systemd: Restart=on-abnormal

### DIFF
--- a/systemd/varnish.service
+++ b/systemd/varnish.service
@@ -5,6 +5,7 @@ After=network-online.target
 [Service]
 Type=forking
 KillMode=process
+Restart=on-abnormal
 
 # Maximum number of open files (for ulimit -n)
 LimitNOFILE=131072


### PR DESCRIPTION
Improve reliability by making sure the system automatically attempts recovering a failing daemon.
Recommendation [here](
https://fedoraproject.org/wiki/Packaging:Systemd#Automatic_restarting) states:

> will tell systemd to restart the daemon as soon as it fails regardless of the precise reason. It's a good choice for most long-running services.