### PR TITLE
Follow vcl.list format change

### DIFF
--- a/systemd/varnishreload
+++ b/systemd/varnishreload
@@ -104,7 +104,7 @@ awk_vcl_list() {
 }
 
 active_vcl() {
-	awk_vcl_list '$1 == "active" {print $4}'
+	awk_vcl_list '$1 == "active" {print $5}'
 }
 
 find_label_ref() {


### PR DESCRIPTION
varnishadm vcl.list format changed by https://github.com/varnishcache/varnish-cache/commit/45239c2413098201a9c32e9fad597e352d694205

varnish 6.1.1
```
ubuntu@proxy03:~$ sudo varnishd -V
varnishd (varnish-6.1.1 revision efc2f6c1536cf2272e471f5cff5f145239b19460)
Copyright (c) 2006 Verdens Gang AS
Copyright (c) 2006-2015 Varnish Software AS
ubuntu@proxy03:~$ sudo varnishadm vcl.list
active      auto/warm         75 boot
```

current master 
```
ubuntu@proxy01:/etc/varnish$ sudo varnishd -V
varnishd (varnish-trunk revision bf55b2fcdb544bb8c2c95a992e3111123c820723)
Copyright (c) 2006 Verdens Gang AS
Copyright (c) 2006-2018 Varnish Software AS
ubuntu@proxy01:/etc/varnish$ sudo varnishadm vcl.list
available   cold    cold         0    boot
available   cold    cold         0    reload_20190307_045228_14801
active      auto    warm        67    reload_20190307_045247_14843

ubuntu@proxy01:/etc/varnish$ sudo varnishadm vcl.list|awk '$1 == "active" {print $4}'
62
ubuntu@proxy01:/etc/varnish$ sudo varnishadm vcl.list|awk '$1 == "active" {print $5}'
reload_20190307_045247_14843

```