### PR TITLE
 Bring backward compatibility back with vcl.list 

### DIFF
--- a/systemd/varnishreload
+++ b/systemd/varnishreload
@@ -100,7 +100,7 @@ vcl_reload_name() {
 }
 
 awk_vcl_list() {
-	printf '%s' "$VCL_LIST" | awk "$@"
+	printf '%s' "$VCL_LIST" | awk -F ' *|/' "$@"
 }
 
 active_vcl() {

--- a/systemd/varnishreload
+++ b/systemd/varnishreload
@@ -108,7 +108,7 @@ active_vcl() {
 }
 
 find_label_ref() {
-	awk_vcl_list '$4 == "'"$VCL_LABEL"'" && $5 == "->" {print $6}'
+	awk_vcl_list '$5 == "'"$VCL_LABEL"'" && $6 == "->" {print $7}'
 }
 
 find_vcl_file() {
@@ -132,9 +132,9 @@ find_vcl_file() {
 }
 
 find_vcl_reloads() {
-	awk_vcl_list 'NF == 4 &&
+	awk_vcl_list 'NF == 5 &&
 		$1 == "available" &&
-		$4 ~ /^reload_[0-9]+_[0-9]+_[0-9]+$/ {print $4}'
+		$5 ~ /^reload_[0-9]+_[0-9]+_[0-9]+$/ {print $5}'
 }
 
 while getopts hl:m:n:w: OPT


### PR DESCRIPTION
Please consider this high priority since we are very close to the next major release.

See individual commits for the details.

I'm planning to try the following platforms:

- Fedora & CentOS (basically, bash)
- FreeBSD
- OpenBSD

I'd like to delegate the testing of the following platforms:

- Debian and Ubuntu (basically, dash)
- SunOS

On Fedora, I will also manually test the script with ksh although I think that's what FreeBSD uses for `/bin/sh` (but I don't remember). The most critical part is that my `awk` change is portable in practice on systems we care about.

What POSIX says about `FS`:

> Input field separator regular expression; a \<space\> by default.

But on my system, it looks like `[ /]` doesn't yield the expected separator. I will dig that specific point on my own, but this pull request... works on my machine.

Refs #121

cc @xcir, please give it a try as well.