### PR TITLE
Require Python 3 runtime and build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,8 +10,8 @@ Build-Depends:
  libncurses-dev,
  libpcre3-dev,
  pkg-config,
- python-docutils,
- python-sphinx,
+ python3-docutils,
+ python3-sphinx,
 Vcs-Git:  git://github.com/varnishcache/pkg-varnish-cache.git
 Homepage: https://www.varnish-cache.org/
 Standards-Version: 3.9.6
@@ -62,7 +62,7 @@ Depends:
  ${misc:Depends},
  varnish (= ${binary:Version}),
  pkg-config,
- python
+ python3 (>= 3.4),
 Provides:
  libvarnish-dev,
  libvarnishapi-dev

--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,9 @@ DISABLE_JEMALLOC_ARCH_LIST := hppa m68k
 DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 
 # Set local state dir for FHS
-LOCAL_CONFIGURE_FLAGS = --localstatedir=/var/lib --libdir=/usr/lib
+LOCAL_CONFIGURE_FLAGS  = --localstatedir=/var/lib --libdir=/usr/lib
+LOCAL_CONFIGURE_FLAGS += --with-sphinx-build=sphinx-build-3
+LOCAL_CONFIGURE_FLAGS += RST2MAN=/usr/share/docutils/scripts/python3/rst2man
 
 ifneq ($(filter $(DEB_HOST_ARCH),$(DISABLE_JEMALLOC_ARCH_LIST)),)
 LOCAL_CONFIGURE_FLAGS += --disable-jemalloc

--- a/redhat/varnish.spec
+++ b/redhat/varnish.spec
@@ -18,9 +18,8 @@ BuildRequires: libedit-devel
 BuildRequires: ncurses-devel
 BuildRequires: pcre-devel
 BuildRequires: pkgconfig
-BuildRequires: python(abi) >= 2.7
-BuildRequires: python-docutils >= 0.6
-BuildRequires: python-sphinx
+BuildRequires: python34-docutils
+BuildRequires: python34-sphinx
 BuildRequires: systemd-units
 
 Requires: gcc
@@ -56,7 +55,7 @@ Summary:   Development files for %{name}
 Group:     System Environment/Libraries
 Requires:  %{name}%{?_isa} = %{version}-%{release}
 Requires:  pkgconfig
-Requires:  python(abi) >= 2.7
+Requires:  python(abi) >= 3.4
 Provides:  varnish-libs-devel%{?_isa} = %{version}-%{release}
 Provides:  varnish-libs-devel = %{version}-%{release}
 Obsoletes: varnish-libs-devel
@@ -72,7 +71,8 @@ Varnish Cache is a high-performance HTTP accelerator
 
 
 %build
-%configure --localstatedir=/var/lib --without-rst2html
+%configure --localstatedir=/var/lib --without-rst2html \
+	--with-sphinx-build=sphinx-build-3.4 RST2MAN=rst2man-3.4
 %make_build V=1
 
 


### PR DESCRIPTION
I managed to build it on el7 and Debian Stretch, I would appreciate more coverage and more eyeballs before merging.

For Varnish 6.x we officially support el7, Debian Stretch and Jessie. If someone has a Buster and some time, it would be nice too.

Should supersede #123.

edit: duh, we also support Ubuntu xenial and bionic, more coverage needed. I just tested bionic.