### PR TITLE
Fix broken pipe in case VCL is larger than pipe buffer

### DIFF
--- a/systemd/varnishreload
+++ b/systemd/varnishreload
@@ -113,13 +113,34 @@ find_label_ref() {
 
 find_vcl_file() {
 	VCL_SHOW=$(varnishadm vcl.show -v "$VCL_NAME" 2>&1) || :
-	VCL_FILE=$(
-		echo "$VCL_SHOW" |
-		awk '$1 == "//" && $2 == "VCL.SHOW" {print; exit}' | {
-			# all this ceremony to handle blanks in FILE
-			read -r DELIM VCL_SHOW INDEX SIZE FILE
-			echo "$FILE"
-		}
+	# The below regexp serves to reliably extract the file name from
+	# the _first_ VCL's C-styled comment encountered.
+	#
+	# The comments have the following format:
+	# // VCL.SHOW <POS> <CHARCOUNT> <FILENAME>
+	# Where POS is a counter for files included in the output (starting from 0)
+	# and CHARCOUNT is the character count of FILENAME.
+	#
+	# Note that a filename can itself contain numbers and spaces,
+	# so the following is a valid input:
+	#
+	# // VCL.SHOW 0 1337 file with 3 spaces.vcl
+	#
+	# ...where the full file name is "file with 3 spaces.vcl"
+	VCL_FILE=$(echo "$VCL_SHOW" | sed -En '
+			# Using the GNU extension "0,regexp" to make sure we match the
+			# very first line of input in the range as well.
+			0,/^\/\/ VCL.SHOW/ {
+				# Match <POS> <CHARCNT> <FNAME> and capture FNAME
+				s/.*[0-9]+ [0-9]+ (.*)$/\1/
+
+				h  # Copy the capture from pattern space to hold space
+			}
+			# match the last line of input
+			${
+				g  # copy the contents of hold space to pattern space
+				p  # print the current line in pattern space
+			}'
 	) || :
 
 	if [ -z "$VCL_FILE" ]


### PR DESCRIPTION
## The issue

In case the output of `vcl.show -w` is larger than the pipe buffer (see [Pipe Capacity](https://linux.die.net/man/7/pipe)), the following chain of commands in `find_vcl_file()` can cause a broken pipe error, resulting in the write side receiving a SIGPIPE:
https://github.com/varnishcache/pkg-varnish-cache/blob/ad4ebad81381cb75d99de2b05105b232b6efa14d/systemd/varnishreload#L116-L123

Alternatively, in case `SIGPIPE` is masked (which is the default in [systemd.exec](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#IgnoreSIGPIPE=)), the `write()` syscall simply fails (see [EPIPE](https://linux.die.net/man/2/write) in `man 2 write`).

## Impact
There seems to be no impact on the script's functionality, as `awk` only exits once a satisfactory input is found. However, that is definitely not clear from the error that can be seen in systemd logs:
```
Nov 01 00:00:00 hostname systemd[1]: Reloading Varnish Cache, a high-performance HTTP accelerator.
Nov 01 00:00:00 hostname varnishreload[14456]: sh: echo: I/O error
Nov 01 00:00:00 hostname varnishreload[14456]: VCL 'reload_20191101_000000_14456' compiled
Nov 01 00:00:00 hostname varnishreload[14456]: VCL 'reload_20191101_000000_14456' now active
Nov 01 00:00:00 hostname systemd[1]: Reloaded Varnish Cache, a high-performance HTTP accelerator.
```

Due to the nature of shells' setup on Debian, `varnishreload` would be executed under `/bin/dash` as that's what `/bin/sh` points to. When the script is modified to be run by `/bin/bash`, we can see the error more clearly:
```
Nov 01 00:00:00 hostname systemd[1]: Reloading Varnish Cache, a high-performance HTTP accelerator.
Nov 01 00:00:00 hostname varnishreload[14456]: line 124: echo: write error: Broken pipe
Nov 01 00:00:00 hostname varnishreload[14456]: VCL 'reload_20191101_000000_14456' compiled
```

## The gory details
The reason this error happens is that once `awk` encounters the desired line, it is instructed to exit, effectively closing the read side of the pipe between `awk` and the writing `echo`. In case the contents of `${VCL_SHOW}` are large enough ( more on that below ), `echo` might not have finished writing the entirety of VCL_SHOW yet, resulting in its `write()` syscall failing and kernel sending it a SIGPIPE (unless it is masked).

The below C code (using GNU extensions) demonstrates this issue:
```C
#define _GNU_SOURCE
#include <errno.h>
#include <fcntl.h>
#include <signal.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/stat.h>
#include <sys/types.h>
#include <unistd.h>

// formatted with clang-format

void handle_sigpipe(int sig) {
  fprintf(stderr, "Caught a SIGPIPE - exiting\n");
  signal(SIGPIPE, SIG_DFL);
  kill(getpid(), sig);
}

void free_buf(int ret, void *buf) { free(buf); }

int main(int argc, char *argv[]) {
  // man 3 program_invocation_short_name
  const char *appname = program_invocation_short_name;

  if (!strcmp(appname, "out_masked")) {
    signal(SIGPIPE, SIG_IGN);
  } else {
    signal(SIGPIPE, handle_sigpipe);
  }

  // F_GETPIPE_SZ is a linux-specific flag available since kernel 2.6.35
  // See `man 7 pipe' for more
  int pipe_sz = fcntl(STDOUT_FILENO, F_GETPIPE_SZ);
  if (pipe_sz == -1) {
    fprintf(stderr,
            "You need to pipe the STDOUT of this command"
            " for the example to work: %s\n",
            strerror(errno));
    return 1;
  }

  /*
   * Read twice the Pipe Capacity number of bytes from /dev/urandom and
   * write it to STDOUT.
   */
  size_t buf_size = 2 * pipe_sz;
  char *buf = NULL;
  on_exit(free_buf, buf); // Won't work for the SIGPIPE case
  buf = (char *)malloc(buf_size);
  if (buf == NULL) {
    fprintf(stderr, "Failed to allocate %z bytes of data: %s", buf_size,
            strerror(errno));
    return 1;
  }
  int urandom_fd = open("/dev/urandom", 0 /*flags*/, S_IRUSR);

  ssize_t rstatus = read(urandom_fd, buf, buf_size);
  if (rstatus == -1) {
    fprintf(stderr, "read() failed: %s\n", strerror(errno));
    return 1;
  }

  ssize_t wstatus = write(STDOUT_FILENO, buf, buf_size);
  if (wstatus == -1) {
    fprintf(stderr, "write() failed: %s\n", strerror(errno));
    return 1;
  }
  return 0;
}
```

If you save the code to `out.c`, the below script will help you compile it and showcase its behaviour when SIGPIPE is/isn't masked:
* When SIGPIPE is masked (can be easily observed in systemd) - echo will handle `write()` returning -1 and setting `errno` to `EPIPE`.
* When SIGPIPE is not masked - echo is killed by SIGPIPE and exits as part of its default sig handler.
The script outputs the values in the `${PIPESTATUS[*]}` array to showcase whether a signal was received.

```sh
#!/bin/bash --posix
​
set -e
set -u
​
BOLD='\e[1m'
WARN='\e[33m'
RESET='\e[0m'
​
PIPE_MAX_SIZE=$(</proc/sys/fs/pipe-max-size)
PAGESIZE=$(getconf PAGESIZE)
PIPE_DEFAULT_SIZE=$((16 * PAGESIZE))
​
# REQUIREMENTS:
#  At least Linux 2.6.35 expected
#  _GNU_SOURCE available
#  GCC
​
SIGPIPE=$(/bin/kill -l PIPE)
​
if (( 2 * PAGESIZE > PIPE_MAX_SIZE)); then
	echo -e "${WARN}Your PIPE_MAX_SIZE is less than twice the default pipe capacity"
	echo -e "This example might not work for you as intended${RESET}"
fi
​
WORKDIR=$(mktemp -d -p /tmp)
pushd "${PWD}" &>/dev/null
trap 'popd; rm -rf "${WORKDIR}"' EXIT
​
# See the section "Pipe capacity" in "man 7 pipe"
​
​
CODE="${PWD}/out.c"
​
cd "${WORKDIR}"
gcc "${CODE}" -o out_default
ln -s out_default out_masked
​
echo -e "${BOLD}Broken pipe without SIGPIPE masked${RESET}:"
​
# From the bash manpage:
# : [arguments]
#      No  effect; the command does nothing beyond expanding arguments and performing any specified redirections.
#      The return status is zero.
./out_default | :
echo "${PIPESTATUS[*]}"
​
​
echo -e "${BOLD}Broken pipe with SIGPIPE masked${RESET}:"
./out_masked | :
echo "${PIPESTATUS[*]}"
```

## The fix
Please see the attached patch. Since the new code always reads in the entire input - even if it will no longer result in any additional output - the broken pipe error effectively cannot happen.  At least not in the case described above, that is. Echo will always have all of its output properly consumed.

There are of course other solutions to this issue, for example the following would probably work equally as well:
```sh
VCL_FILE=$(echo “$VCL_SHOW” |  grep -E '^// VCL.SHOW [0-9]+ [0-9]+' | cut -d' ' -f5- | head -n1)
```