### PR TITLE
Optimizations from PR 3263

### DIFF
--- a/alpine/APKBUILD
+++ b/alpine/APKBUILD
@@ -21,7 +21,7 @@ options="!check" # tests pass, but ran before packaging
 depends="gcc libc-dev libgcc"
 depends_dev=
 makedepends="$depends_dev pcre-dev ncurses-dev libedit-dev py-docutils
-	linux-headers libunwind-dev python py3-sphinx"
+	linux-headers libunwind-dev python3 py3-sphinx"
 install="$pkgname.pre-install"
 subpackages="$pkgname-dbg $pkgname-dev $pkgname-doc $pkgname-libs"
 pkgusers="varnish"

--- a/redhat/varnish.spec
+++ b/redhat/varnish.spec
@@ -18,7 +18,11 @@ BuildRequires: libedit-devel
 BuildRequires: ncurses-devel
 BuildRequires: pcre-devel
 BuildRequires: pkgconfig
+BuildRequires: python3
 BuildRequires: python3-sphinx
+BuildRequires: make
+BuildRequires: gcc
+BuildRequires: diffutils
 
 Requires: gcc
 Requires: logrotate

--- a/redhat/varnish.spec
+++ b/redhat/varnish.spec
@@ -1,3 +1,4 @@
+%global __python %{__python3}
 %global vd_rc %{?v_rc:0.%{?v_rc}.}
 %global debug_package %{nil}
 %global _use_internal_dependency_generator 0

--- a/redhat/varnish.spec
+++ b/redhat/varnish.spec
@@ -14,16 +14,16 @@ Group:   System Environment/Daemons
 URL:     https://www.varnish-cache.org/
 Source:  %{srcname}.tgz
 
+BuildRequires: diffutils
+BuildRequires: gcc
 BuildRequires: jemalloc-devel
 BuildRequires: libedit-devel
+BuildRequires: make
 BuildRequires: ncurses-devel
 BuildRequires: pcre-devel
 BuildRequires: pkgconfig
 BuildRequires: python3
 BuildRequires: python3-sphinx
-BuildRequires: make
-BuildRequires: gcc
-BuildRequires: diffutils
 
 Requires: gcc
 Requires: logrotate


### PR DESCRIPTION
Hello,

Here are some optimizations from https://github.com/varnishcache/varnish-cache/pull/3263.
Namely, some dependencies have been moved from `yum install`/`apk add` to their respective package descriptors.