### PR TITLE
Extra opts

### DIFF
--- a/systemd/varnish.service
+++ b/systemd/varnish.service
@@ -21,7 +21,10 @@ TasksMax=infinity
 # Maximum size of the corefile.
 LimitCORE=infinity
 
-ExecStart=/usr/sbin/varnishd -a :6081 -f /etc/varnish/default.vcl -s malloc,256m
+ExecStart=/usr/sbin/varnishd \
+	  -a :6081 \
+	  -f /etc/varnish/default.vcl \
+	  -s malloc,256m
 ExecReload=/usr/sbin/varnishreload
 
 [Install]

--- a/systemd/varnish.service
+++ b/systemd/varnish.service
@@ -23,6 +23,7 @@ LimitCORE=infinity
 
 ExecStart=/usr/sbin/varnishd \
 	  -a :6081 \
+	  -a localhost:8443,PROXY \
 	  -f /etc/varnish/default.vcl \
 	  -s malloc,256m
 ExecReload=/usr/sbin/varnishreload

--- a/systemd/varnish.service
+++ b/systemd/varnish.service
@@ -24,6 +24,7 @@ LimitCORE=infinity
 ExecStart=/usr/sbin/varnishd \
 	  -a :6081 \
 	  -a localhost:8443,PROXY \
+	  -p feature=+http2 \
 	  -f /etc/varnish/default.vcl \
 	  -s malloc,256m
 ExecReload=/usr/sbin/varnishreload


### PR DESCRIPTION
Small PR, but it could be contentious as it touches the default runtime options: listen to `PROXY` protocol on 8443 and activate `H/2`.

This would only change setups that haven't modified the `Execstart=` directove, which I believe are a minority. In return, it will offer super easy `hitch` integration.