### PR TITLE
removing systemd_requires

### DIFF
--- a/redhat/varnish.spec
+++ b/redhat/varnish.spec
@@ -25,13 +25,13 @@ BuildRequires: pcre2-devel
 BuildRequires: pkgconfig
 BuildRequires: python3
 BuildRequires: python3-sphinx
+%if 0%{?fedora}
+BuildRequires: systemd-rpm-macros
+%endif
+%{?systemd_requires}
 
 Requires: gcc
 Requires: logrotate
-%systemd_requires
-%if 0%{?rhel} >= 8
-Requires: redhat-rpm-config
-%endif
 
 Provides:  varnish-libs%{?_isa} = %{version}-%{release}
 Provides:  varnish-libs = %{version}-%{release}


### PR DESCRIPTION
the `systemd_requires` macro doesn't seem to work anymore on the latest stable `fedora` (it triggers an `unknown tag` error), so I copied what I saw in the official fedora package.

for context: I'm preparing a PR on the varnish-cache repository getting rid of `centos:8` and adding `fedora:latest` and `fedora:rawhide`, that's how I hit that error.

tagging @Dridi and @ingvarha because they know this part of the woods