### PR TITLE
varnishreload: Ensure a consistent help usage

### DIFF
--- a/systemd/varnishreload
+++ b/systemd/varnishreload
@@ -73,7 +73,7 @@ usage() {
 	Upon success, the name of the loaded VCL is constructed from the
 	prefix, current date and time, like for example:
 
-	    $(vcl_reload_name)
+	    $(VCL_PREFIX=reload vcl_reload_name)
 
 	Afterwards available VCLs created by this script are discarded until
 	<max> are left, unless it was empty or undefined. VCLs referenced by

--- a/systemd/varnishreload
+++ b/systemd/varnishreload
@@ -102,7 +102,7 @@ fail() {
 vcl_reload_name() {
 	# NB: The PID compensates the lack of sub-second resolution.
 	# Varnish will vcl.list in chronological vcl.load order anyway.
-	printf "%s_%s" "$VCL_PREFIX" "$(date -u +%Y%m%d_%H%M%S_$$)"
+	printf '%s_%s_%s' "$VCL_PREFIX" "$(date -u +%Y%m%d_%H%M%S)" $$
 }
 
 awk_vcl_list() {


### PR DESCRIPTION
Otherwise the VCL prefix would be subject to the -p option.