### PR TITLE
Explicitly disable LTO, which became default from Ubuntu 21.04 and onwards

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,9 @@ DH_VERBOSE=1
 # List of architectures where jemalloc is not available
 DISABLE_JEMALLOC_ARCH_LIST := hppa m68k
 
+# Explicitly disable LTO, which became default from Ubuntu 21.04 and onwards
+export DEB_BUILD_MAINT_OPTIONS=optimize=-lto
+
 # Explicitly initialize a variable to select architecture, unless it has been
 # defined before.  This is compared against the DISABLE_*_LIST variables later
 # in this makefile


### PR DESCRIPTION
Fixes #159 