### PR TITLE
deb: Install the directory for VCC files

### DIFF
--- a/debian/varnish.install
+++ b/debian/varnish.install
@@ -3,6 +3,7 @@ usr/bin/*
 usr/sbin/*
 usr/lib/varnish
 usr/share/man
+usr/share/varnish/vcc
 usr/share/varnish/vcl
 debian/*.service lib/systemd/system/
 usr/share/doc/varnish/*.vcl


### PR DESCRIPTION
Refs varnishcache/varnish-cache#3909

---

Other packaging formats don't look like they need to be adapted to this change.