### PR TITLE
Changed varnishreload to send commands to varnishadm as a batch

### DIFF
--- a/systemd/varnishreload
+++ b/systemd/varnishreload
@@ -207,21 +207,19 @@ fi
 
 RELOAD_NAME=$(vcl_reload_name)
 
-varnishadm vcl.load "$RELOAD_NAME" "\"$VCL_FILE\"" >/dev/null
-echo "VCL '$RELOAD_NAME' compiled"
+{
+	echo vcl.load "$RELOAD_NAME" "\"$VCL_FILE\""
 
-test -n "$WARMUP" && sleep "$WARMUP"
+	test -n "$WARMUP" && sleep "$WARMUP"
 
-if [ -n "$VCL_LABEL" ]
-then
-	varnishadm vcl.label "$VCL_LABEL" "$RELOAD_NAME" >/dev/null
-	echo "VCL label '$VCL_LABEL' references '$RELOAD_NAME'"
-fi
+	if [ -n "$VCL_LABEL" ]; then
+		echo vcl.label "$VCL_LABEL" "$RELOAD_NAME"
+	fi
 
-if [ "$VCL_NAME" = "$(active_vcl)" ]
-then
-	varnishadm vcl.use "$RELOAD_NAME"
-fi
+	if [ "$VCL_NAME" = "$(active_vcl)" ]; then
+		echo vcl.use "$RELOAD_NAME"
+	fi
+} | varnishadm
 
 test -n "$MAXIMUM" || exit 0
 test "$MAXIMUM" -ge 0 || exit 0


### PR DESCRIPTION
This fixes #168, but comes with some trade-offs:

1. We can no longer decorate the output of `varnishadm` with our own. This is unavoidable as far as I know, with the limitations of Bash.

    I even tried assigning STDOUT to FD3 and sending our decorations using `>&3 echo` invocations, but this causes all our decorations to either appear before all output emitted by `varnishadm`, or after, depending on the specific semantics used, but there is no way to interlace our output with that of `varnishadm` in the intuitive manner we expect (as previously).
4. Due to a bug in `varnishadm`, output cannot be suppressed when the commands are successful since any commands so sent via STDIN will always cause `varnishadm` to exit with 0 (success) status. See: varnishcache/varnish-cache/issues/4012.


