### PR TITLE
Add timeout(-t) option

### DIFF
--- a/systemd/varnishreload
+++ b/systemd/varnishreload
@@ -46,7 +46,7 @@ usage() {
 
 	cat <<-EOF
 	Usage: $SCRIPT [-l <label>] [-m <max>] [-n <workdir>]
-	           [-p <prefix>] [-w <warmup>] [<file>]
+	           [-p <prefix>] [-t <timeout>] [-w <warmup>] [<file>]
 	       $SCRIPT -h
 
 	Reload and use a VCL on a running Varnish instance.
@@ -57,8 +57,8 @@ usage() {
 	-m <max>     : maximum number of available reloads to leave behind
 	-n <workdir> : specify the name or directory for the varnishd instance
 	-p <prefix>  : prefix for the name of the loaded and discarded VCLs
-	-w <warmup>  : the number of seconds between load and use operations
 	-t <timeout> : the number of seconds to wait for varnishadm to finish
+	-w <warmup>  : the number of seconds between load and use operations
 
 	When <label> is empty or missing, the active VCL is reloaded. If the
 	reloaded VCL is a label, the underlying VCL program is reloaded, and
@@ -135,7 +135,7 @@ find_vcl_reloads() {
 		$5 ~ regex {print $5}'
 }
 
-while getopts hl:m:n:p:w:t: OPT
+while getopts hl:m:n:p:t:w: OPT
 do
 	case $OPT in
 	h) usage ;;
@@ -143,8 +143,8 @@ do
 	m) MAXIMUM=$OPTARG ;;
 	n) WORK_DIR=$OPTARG ;;
 	p) VCL_PREFIX=$OPTARG ;;
-	w) WARMUP=$OPTARG ;;
 	t) TIMEOUT="-t $OPTARG" ;;
+	w) WARMUP=$OPTARG ;;
 	*) usage "wrong usage" >&2 ;;
 	esac
 done

--- a/systemd/varnishreload
+++ b/systemd/varnishreload
@@ -35,6 +35,7 @@ VCL_FILE=
 VCL_LABEL=
 VCL_NAME=
 WARMUP=
+TIMEOUT=
 WORK_DIR=
 
 SCRIPT=$0
@@ -57,6 +58,7 @@ usage() {
 	-n <workdir> : specify the name or directory for the varnishd instance
 	-p <prefix>  : prefix for the name of the loaded and discarded VCLs
 	-w <warmup>  : the number of seconds between load and use operations
+	-t <timeout> : the number of seconds to wait for varnishadm to finish
 
 	When <label> is empty or missing, the active VCL is reloaded. If the
 	reloaded VCL is a label, the underlying VCL program is reloaded, and
@@ -83,9 +85,9 @@ usage() {
 }
 
 varnishadm() {
-	if ! OUTPUT=$(command varnishadm -n "$WORK_DIR" -- "$@" 2>&1)
+	if ! OUTPUT=$(command varnishadm $TIMEOUT -n "$WORK_DIR" -- "$@" 2>&1)
 	then
-		echo "Command: varnishadm -n '$WORK_DIR' -- $*"
+		echo "Command: varnishadm $TIMEOUT -n '$WORK_DIR' -- $*"
 		echo
 		echo "$OUTPUT"
 		echo
@@ -133,7 +135,7 @@ find_vcl_reloads() {
 		$5 ~ regex {print $5}'
 }
 
-while getopts hl:m:n:p:w: OPT
+while getopts hl:m:n:p:w:t: OPT
 do
 	case $OPT in
 	h) usage ;;
@@ -142,6 +144,7 @@ do
 	n) WORK_DIR=$OPTARG ;;
 	p) VCL_PREFIX=$OPTARG ;;
 	w) WARMUP=$OPTARG ;;
+	t) TIMEOUT="-t $OPTARG" ;;
 	*) usage "wrong usage" >&2 ;;
 	esac
 done


### PR DESCRIPTION
fix #168 


```
# default (vcl is large)
ubuntu@proxy04:~$ sudo ./varnishreload      
Command: varnishadm  -n '' -- vcl.load reload_20240709_143005_1773848 "/etc/varnish/default.vcl"

CLI communication error (hdr)

# reload succeeded by specifying a large timeout.
ubuntu@proxy04:~$ sudo ./varnishreload -t 10
VCL 'reload_20240709_143022_1774368' compiled
VCL 'reload_20240709_143022_1774368' now active
```