### PR TITLE
Do not limit locked memory by default

### DIFF
--- a/systemd/varnish.service
+++ b/systemd/varnish.service
@@ -9,11 +9,11 @@ KillMode=mixed
 # Maximum number of open files (for ulimit -n)
 LimitNOFILE=131072
 
-# Shared memory (VSM) segments are tentatively locked in memory. The
-# default value for vsl_space (or shorthand varnishd -l option) is 80MB.
-# There are other types of segments that would benefit from allowing
-# more memory to be locked.
-LimitMEMLOCK=100M
+# Shared memory (VSM) segments are tentatively locked in memory.
+#
+# Varnish will only lock memory in useful ways, so applying an external limit is
+# not helpful.
+LimitMEMLOCK=infinity
 
 # Enable this to avoid "fork failed" on reload.
 TasksMax=infinity

--- a/sysv/debian/varnish.default
+++ b/sysv/debian/varnish.default
@@ -14,9 +14,8 @@ START=yes
 NFILES=131072
 
 # Maximum locked memory size (for ulimit -l)
-# Used for locking the shared memory log in memory.  If you increase log size,
-# you need to increase this number as well
-MEMLOCK=82000
+# Not limited by default
+MEMLOCK=unlimited
 
 DAEMON_OPTS="-a :6081 \
              -f /etc/varnish/default.vcl \

--- a/sysv/debian/varnish.init
+++ b/sysv/debian/varnish.init
@@ -32,8 +32,8 @@ fi
 # Open files (usually 1024, which is way too small for varnish)
 ulimit -n ${NFILES:-131072}
 
-# Maxiumum locked memory size for shared memory log
-ulimit -l ${MEMLOCK:-82000}
+# Do not limit locked memory
+ulimit -l ${MEMLOCK:-unlimited}
 
 # If $DAEMON_OPTS is not set at all in /etc/default/varnish, use minimal useful
 # defaults (Backend at localhost:8080, a common place to put a locally

--- a/sysv/redhat/varnish.initrc
+++ b/sysv/redhat/varnish.initrc
@@ -54,7 +54,7 @@ start() {
 	ulimit -n ${NFILES:-131072}
 
 	# Varnish wants to lock shared memory log in memory.
-	ulimit -l ${MEMLOCK:-82000}
+	ulimit -l ${MEMLOCK:-unlimited}
 
 	# Maximum number of threads (default in CentOS is 1024, which
 	# is often too small for varnish)

--- a/sysv/redhat/varnish.sysconfig
+++ b/sysv/redhat/varnish.sysconfig
@@ -8,8 +8,8 @@
 NFILES=131072
 
 # Locked shared memory (for ulimit -l)
-# Default log size is 82MB + header
-MEMLOCK=82000
+# Default is unlimited
+MEMLOCK="unlimited"
 
 # Maximum number of threads (for ulimit -u)
 NPROCS="unlimited"


### PR DESCRIPTION
See https://github.com/varnishcache/varnish-cache/issues/4193 and https://github.com/varnishcache/varnish-cache/issues/4121 for context:

It does not make sense (any more) to apply an external limit on the maximum locked memory: We should trust Varnish-Cache to only attempt mlock(2) where it makes sense, and the amount of VSM grows dynamically with backends, vmods etc, so it is far from trivial to calculate a sensible maximum.