### PR TITLE
Update control to remove pcre3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,6 @@ Build-Depends:
  libjemalloc-dev,
  libncurses-dev,
  libpcre2-dev,
- libpcre3-dev,
  pkg-config,
  python3-docutils,
  python3-sphinx,


### PR DESCRIPTION
libpcre3-dev is no longer a part of Debian OS trixie.

Anyone aware if this dependency is required? Building 7.7.X on trixie seems to work without it..