### PR TITLE
[rpm] don't depend on `pcre1`

### DIFF
--- a/redhat/varnish.spec
+++ b/redhat/varnish.spec
@@ -23,7 +23,6 @@ BuildRequires: jemalloc-devel
 BuildRequires: libedit-devel
 BuildRequires: make
 BuildRequires: ncurses-devel
-BuildRequires: pcre-devel
 BuildRequires: pcre2-devel
 BuildRequires: pkgconfig
 BuildRequires: python3


### PR DESCRIPTION
we don't use it anymore, and we already depend on `pcre2`